### PR TITLE
fix merkle tree malleability

### DIFF
--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -163,13 +163,13 @@ impl Hashed for HPair {
 	}
 }
 /// An iterator over hashes in a vector that pairs them to build a row in a
-/// Merkle tree. If the vector has an odd number of hashes, duplicates the last.
+/// Merkle tree. If the vector has an odd number of hashes, it appends a zero hash
 struct HPairIter(Vec<Hash>);
 impl Iterator for HPairIter {
 	type Item = HPair;
 
 	fn next(&mut self) -> Option<HPair> {
-		self.0.pop().map(|first| HPair(first, self.0.pop().unwrap_or(first)))
+		self.0.pop().map(|first| HPair(first, self.0.pop().unwrap_or(ZERO_HASH)))
 	}
 }
 /// A row in a Merkle tree. Can be built from a vector of hashes. Calculates

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -164,6 +164,8 @@ impl Hashed for HPair {
 }
 /// An iterator over hashes in a vector that pairs them to build a row in a
 /// Merkle tree. If the vector has an odd number of hashes, it appends a zero hash
+/// See https://bitcointalk.org/index.php?topic=102395.0 CVE-2012-2459 (block merkle calculation exploit)
+/// for the argument against duplication of last hash
 struct HPairIter(Vec<Hash>);
 impl Iterator for HPairIter {
 	type Item = HPair;


### PR DESCRIPTION
Duplicating last transaction hash for odd number of tree leafs allows for malleability, as
MerkleHash([a,b,c])=MerkleHash([a,b,c,c])
The receiver could not tell if the tree had odd number of leafs or the tree was corrupt containing transaction c twice. 

To fix, define
MerkleHash[a,b,c]=MerkleHash([a,b,c,0])

Assuming that it is impossible to create valid transaction with hash 0

This issue came up with Bitcoin, see https://bitcointalk.org/index.php?topic=102395.0