### PR TITLE
core: Clean up serialization and hashing

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -60,7 +60,7 @@ impl Default for BlockHeader {
 // Only Writeable implementation is required for hashing, which is part of
 // core. Readable is in the ser package.
 impl Writeable for BlockHeader {
-	fn write(&self, writer: &mut Writer) -> Option<ser::Error> {
+	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
 		ser_multiwrite!(writer,
 		                [write_u64, self.height],
 		                [write_fixed_bytes, &self.previous],
@@ -70,10 +70,10 @@ impl Writeable for BlockHeader {
 		                [write_u64, self.total_fees]);
 		// make sure to not introduce any variable length data before the nonce to
 		// avoid complicating PoW
-		try_o!(writer.write_u64(self.nonce));
+		try!(writer.write_u64(self.nonce));
 		// cuckoo cycle of 42 nodes
 		for n in 0..42 {
-			try_o!(writer.write_u32(self.pow.0[n]));
+			try!(writer.write_u32(self.pow.0[n]));
 		}
 		writer.write_u64(self.td)
 	}
@@ -101,23 +101,23 @@ pub struct Block {
 /// Implementation of Writeable for a block, defines how to write the full
 /// block as binary.
 impl Writeable for Block {
-	fn write(&self, writer: &mut Writer) -> Option<ser::Error> {
-		try_o!(self.header.write(writer));
+	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
+		try!(self.header.write(writer));
 
 		ser_multiwrite!(writer,
 		                [write_u64, self.inputs.len() as u64],
 		                [write_u64, self.outputs.len() as u64],
 		                [write_u64, self.proofs.len() as u64]);
 		for inp in &self.inputs {
-			try_o!(inp.write(writer));
+			try!(inp.write(writer));
 		}
 		for out in &self.outputs {
-			try_o!(out.write(writer));
+			try!(out.write(writer));
 		}
 		for proof in &self.proofs {
-			try_o!(proof.write(writer));
+			try!(proof.write(writer));
 		}
-		None
+		Ok(())
 	}
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -26,7 +26,7 @@ use core::transaction::merkle_inputs_outputs;
 use core::{PROOFSIZE, REWARD};
 use core::hash::{Hash, Hashed, ZERO_HASH};
 use core::transaction::MAX_IN_OUT_LEN;
-use ser::{self, Readable, Reader, Writeable, Writer, ser_vec};
+use ser::{self, Readable, Reader, Writeable, Writer};
 
 /// Block header, fairly standard compared to other blockchains.
 pub struct BlockHeader {
@@ -76,13 +76,6 @@ impl Writeable for BlockHeader {
 			try!(writer.write_u32(self.pow.0[n]));
 		}
 		writer.write_u64(self.td)
-	}
-}
-
-impl Hashed for BlockHeader {
-	fn bytes(&self) -> Vec<u8> {
-		// no serialization errors are applicable in this specific case
-		ser_vec(self).unwrap()
 	}
 }
 

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -17,7 +17,7 @@
 //! Primary hash function used in the protocol
 //!
 
-use byteorder::{ByteOrder, WriteBytesExt, BigEndian};
+use byteorder::{ByteOrder, BigEndian};
 use std::fmt;
 use tiny_keccak::Keccak;
 

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -18,24 +18,17 @@ pub mod block;
 pub mod hash;
 pub mod transaction;
 #[allow(dead_code)]
-#[macro_use]
 
 pub use self::block::{Block, BlockHeader};
 pub use self::transaction::{Transaction, Input, Output, TxProof};
 use self::hash::{Hash, Hashed, ZERO_HASH};
-use ser::{Writeable, Writer, Error, ser_vec};
-
-use time;
+use ser::{Writeable, Writer, Error};
 
 use std::fmt;
 use std::cmp::Ordering;
 
-use secp;
-use secp::{Secp256k1, Signature, Message};
-use secp::key::SecretKey;
+use secp::{self, Secp256k1};
 use secp::pedersen::*;
-
-use tiny_keccak::Keccak;
 
 /// The block subsidy amount
 pub const REWARD: u64 = 1_000_000_000;
@@ -198,7 +191,7 @@ impl MerkleRow {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use super::hash::{Hash, Hashed, ZERO_HASH};
+	use core::hash::ZERO_HASH;
 	use secp;
 	use secp::Secp256k1;
 	use secp::key::SecretKey;

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -154,12 +154,12 @@ impl Proof {
 /// Two hashes that will get hashed together in a Merkle tree to build the next
 /// level up.
 struct HPair(Hash, Hash);
-impl Hashed for HPair {
-	fn bytes(&self) -> Vec<u8> {
-		let mut data = Vec::with_capacity(64);
-		data.extend_from_slice(self.0.to_slice());
-		data.extend_from_slice(self.1.to_slice());
-		return data;
+
+impl Writeable for HPair {
+	fn write(&self, writer: &mut Writer) -> Result<(), Error> {
+		try!(writer.write_bytes(&self.0.to_slice()));
+		try!(writer.write_bytes(&self.1.to_slice()));
+		Ok(())
 	}
 }
 /// An iterator over hashes in a vector that pairs them to build a row in a

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -378,7 +378,6 @@ mod test {
 
 	use secp::{self, Secp256k1};
 	use secp::key::SecretKey;
-	use rand::Rng;
 	use rand::os::OsRng;
 
 	fn new_secp() -> Secp256k1 {

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -304,7 +304,7 @@ pub enum Output {
 impl Writeable for Output {
 	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
 		try!(writer.write_fixed_bytes(&self.commitment().unwrap()));
-		writer.write_bytes(&mut self.proof().unwrap().bytes())
+		writer.write_bytes(&self.proof().unwrap().bytes())
 	}
 }
 

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -41,7 +41,7 @@ pub struct TxProof {
 impl Writeable for TxProof {
 	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
 		try!(writer.write_fixed_bytes(&self.remainder));
-		writer.write_vec(&mut self.sig.clone())
+		writer.write_bytes(&self.sig)
 	}
 }
 
@@ -71,7 +71,7 @@ impl Writeable for Transaction {
 	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
 		ser_multiwrite!(writer,
 		                [write_u64, self.fee],
-		                [write_vec, &mut self.zerosig.clone()],
+		                [write_bytes, &self.zerosig],
 		                [write_u64, self.inputs.len() as u64],
 		                [write_u64, self.outputs.len() as u64]);
 		for inp in &self.inputs {
@@ -304,7 +304,7 @@ pub enum Output {
 impl Writeable for Output {
 	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
 		try!(writer.write_fixed_bytes(&self.commitment().unwrap()));
-		writer.write_vec(&mut self.proof().unwrap().bytes().to_vec())
+		writer.write_bytes(&mut self.proof().unwrap().bytes())
 	}
 }
 

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -61,19 +61,6 @@ macro_rules! tee {
   }
 }
 
-/// Simple equivalent of try! but for an Option<Error>. Motivated mostly by the
-/// io package and our serialization as an alternative to silly Result<(),
-/// Error>.
-#[macro_export]
-macro_rules! try_o {
-  ($trying:expr) => {
-		let tried = $trying;
-		if let Some(_) = tried {
-			return tried;
-		}
-  }
-}
-
 #[macro_export]
 macro_rules! try_to_o {
   ($trying:expr) => {{
@@ -109,6 +96,6 @@ macro_rules! ser_multiread {
 #[macro_export]
 macro_rules! ser_multiwrite {
   ($wrtr:ident, $([ $write_call:ident, $val:expr ]),* ) => {
-    $( try_o!($wrtr.$write_call($val)) );*
+    $( try!($wrtr.$write_call($val)) );*
   }
 }

--- a/core/src/pow/cuckoo.rs
+++ b/core/src/pow/cuckoo.rs
@@ -19,7 +19,6 @@
 
 use std::collections::HashSet;
 use std::cmp;
-use std::fmt;
 
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -27,12 +27,12 @@ mod cuckoo;
 
 use time;
 
-use core::{Block, BlockHeader, Proof, PROOFSIZE};
+use core::{Block, Proof, PROOFSIZE};
 use core::hash::{Hash, Hashed};
 use pow::cuckoo::{Cuckoo, Miner, Error};
 
 use ser;
-use ser::{Writeable, Writer, ser_vec};
+use ser::{Writeable, Writer};
 
 /// Default Cuckoo Cycle size shift used is 28. We may decide to increase it.
 /// when difficuty increases.
@@ -169,9 +169,7 @@ fn pow_size(b: &Block, target: Proof, sizeshift: u32) -> Result<(Proof, u64), Er
 #[cfg(test)]
 mod test {
 	use super::*;
-	use core::{BlockHeader, Proof};
-	use core::hash::Hash;
-	use std::time::Instant;
+	use core::Proof;
 	use genesis;
 
 	#[test]

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -85,13 +85,6 @@ impl Writeable for PowHeader {
 	}
 }
 
-impl Hashed for PowHeader {
-	fn bytes(&self) -> Vec<u8> {
-		// no serialization errors are applicable in this specific case
-		ser_vec(self).unwrap()
-	}
-}
-
 impl PowHeader {
 	fn from_block(b: &Block) -> PowHeader {
 		let ref h = b.header;

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -71,16 +71,16 @@ struct PowHeader {
 /// the data that gets hashed for PoW calculation. The nonce is written first
 /// to make incrementing from the serialized form trivial.
 impl Writeable for PowHeader {
-	fn write(&self, writer: &mut Writer) -> Option<ser::Error> {
-		try_o!(writer.write_u64(self.nonce));
-		try_o!(writer.write_u64(self.height));
-		try_o!(writer.write_fixed_bytes(&self.previous));
-		try_o!(writer.write_i64(self.timestamp.to_timespec().sec));
-		try_o!(writer.write_fixed_bytes(&self.utxo_merkle));
-		try_o!(writer.write_fixed_bytes(&self.tx_merkle));
-		try_o!(writer.write_u64(self.total_fees));
-		try_o!(writer.write_u64(self.n_in));
-		try_o!(writer.write_u64(self.n_out));
+	fn write(&self, writer: &mut Writer) -> Result<(), ser::Error> {
+		try!(writer.write_u64(self.nonce));
+		try!(writer.write_u64(self.height));
+		try!(writer.write_fixed_bytes(&self.previous));
+		try!(writer.write_i64(self.timestamp.to_timespec().sec));
+		try!(writer.write_fixed_bytes(&self.utxo_merkle));
+		try!(writer.write_fixed_bytes(&self.tx_merkle));
+		try!(writer.write_u64(self.total_fees));
+		try!(writer.write_u64(self.n_in));
+		try!(writer.write_u64(self.n_out));
 		writer.write_u64(self.n_proofs)
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -19,8 +19,8 @@
 //! To use it simply implement `Writeable` or `Readable` and then use the
 //! `serialize` or `deserialize` functions on them as appropriate.
 
-use std::io;
-use std::io::{Write, Read};
+use std::{error, fmt};
+use std::io::{self, Write, Read};
 use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
 
 /// Possible errors deriving from serializing or deserializing.
@@ -33,10 +33,45 @@ pub enum Error {
 		expected: Vec<u8>,
 		received: Vec<u8>,
 	},
-  /// Data wasn't in a consumable format
-  CorruptedData,
+	/// Data wasn't in a consumable format
+	CorruptedData,
 	/// When asked to read too much data
 	TooLargeReadErr(String),
+}
+
+impl From<io::Error> for Error {
+	fn from(e: io::Error) -> Error {
+		Error::IOErr(e)
+	}
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			Error::IOErr(ref e) => write!(f, "{}", e),
+			Error::UnexpectedData { expected: ref e, received: ref r } => write!(f, "expected {:?}, got {:?}", e, r),
+			Error::CorruptedData => f.write_str("corrupted data"),
+			Error::TooLargeReadErr(ref s) => f.write_str(&s)
+		}
+	}
+}
+
+impl error::Error for Error {
+	fn cause(&self) -> Option<&error::Error> {
+		match *self {
+			Error::IOErr(ref e) => Some(e),
+			_ => None
+		}
+	}
+
+	fn description(&self) -> &str {
+		match *self {
+			Error::IOErr(ref e) => error::Error::description(e),
+			Error::UnexpectedData { expected: _, received: _ } => "unexpected data",
+			Error::CorruptedData => "corrupted data",
+			Error::TooLargeReadErr(ref s) => s
+		}
+	}
 }
 
 /// Useful trait to implement on types that can be translated to byte slices
@@ -50,21 +85,21 @@ pub trait AsFixedBytes {
 /// written to an underlying stream or container (depending on implementation).
 pub trait Writer {
 	/// Writes a u8 as bytes
-	fn write_u8(&mut self, n: u8) -> Option<Error>;
+	fn write_u8(&mut self, n: u8) -> Result<(), Error>;
 	/// Writes a u16 as bytes
-	fn write_u16(&mut self, n: u16) -> Option<Error>;
+	fn write_u16(&mut self, n: u16) -> Result<(), Error>;
 	/// Writes a u32 as bytes
-	fn write_u32(&mut self, n: u32) -> Option<Error>;
+	fn write_u32(&mut self, n: u32) -> Result<(), Error>;
 	/// Writes a u64 as bytes
-	fn write_u64(&mut self, n: u64) -> Option<Error>;
+	fn write_u64(&mut self, n: u64) -> Result<(), Error>;
 	/// Writes a i64 as bytes
-	fn write_i64(&mut self, n: i64) -> Option<Error>;
+	fn write_i64(&mut self, n: i64) -> Result<(), Error>;
 	/// Writes a variable length `Vec`, the length of the `Vec` is encoded as a
 	/// prefix.
-	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Option<Error>;
+	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Result<(), Error>;
 	/// Writes a fixed number of bytes from something that can turn itself into
 	/// a `&[u8]`. The reader is expected to know the actual length on read.
-	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Option<Error>;
+	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Result<(), Error>;
 }
 
 /// Implementations defined how different numbers and binary structures are
@@ -98,7 +133,7 @@ pub trait Reader {
 /// underlying Write implementation.
 pub trait Writeable {
 	/// Write the data held by this Writeable to the provided writer
-	fn write(&self, writer: &mut Writer) -> Option<Error>;
+	fn write(&self, writer: &mut Writer) -> Result<(), Error>;
 }
 
 /// Trait that every type that can be deserialized from binary must implement.
@@ -116,7 +151,7 @@ pub fn deserialize<T: Readable<T>>(mut source: &mut Read) -> Result<T, Error> {
 }
 
 /// Serializes a Writeable into any std::io::Write implementation.
-pub fn serialize(mut sink: &mut Write, thing: &Writeable) -> Option<Error> {
+pub fn serialize(mut sink: &mut Write, thing: &Writeable) -> Result<(), Error> {
 	let mut writer = BinWriter { sink: sink };
 	thing.write(&mut writer)
 }
@@ -125,9 +160,7 @@ pub fn serialize(mut sink: &mut Write, thing: &Writeable) -> Option<Error> {
 /// Vec<u8>.
 pub fn ser_vec(thing: &Writeable) -> Result<Vec<u8>, Error> {
 	let mut vec = Vec::new();
-	if let Some(err) = serialize(&mut vec, thing) {
-		return Err(err);
-	}
+	try!(serialize(&mut vec, thing));
 	Ok(vec)
 }
 
@@ -192,33 +225,40 @@ struct BinWriter<'a> {
 }
 
 impl<'a> Writer for BinWriter<'a> {
-	fn write_u8(&mut self, n: u8) -> Option<Error> {
-		self.sink.write_u8(n).err().map(Error::IOErr)
+	fn write_u8(&mut self, n: u8) -> Result<(), Error> {
+		try!(self.sink.write_u8(n));
+		Ok(())
 	}
-	fn write_u16(&mut self, n: u16) -> Option<Error> {
-		self.sink.write_u16::<BigEndian>(n).err().map(Error::IOErr)
+	fn write_u16(&mut self, n: u16) -> Result<(), Error> {
+		try!(self.sink.write_u16::<BigEndian>(n));
+		Ok(())
 	}
-	fn write_u32(&mut self, n: u32) -> Option<Error> {
-		self.sink.write_u32::<BigEndian>(n).err().map(Error::IOErr)
-	}
-
-	fn write_u64(&mut self, n: u64) -> Option<Error> {
-		self.sink.write_u64::<BigEndian>(n).err().map(Error::IOErr)
-	}
-
-	fn write_i64(&mut self, n: i64) -> Option<Error> {
-		self.sink.write_i64::<BigEndian>(n).err().map(Error::IOErr)
+	fn write_u32(&mut self, n: u32) -> Result<(), Error> {
+		try!(self.sink.write_u32::<BigEndian>(n));
+		Ok(())
 	}
 
-
-	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Option<Error> {
-		try_o!(self.write_u64(vec.len() as u64));
-		self.sink.write_all(vec).err().map(Error::IOErr)
+	fn write_u64(&mut self, n: u64) -> Result<(), Error> {
+		try!(self.sink.write_u64::<BigEndian>(n));
+		Ok(())
 	}
 
-	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Option<Error> {
+	fn write_i64(&mut self, n: i64) -> Result<(), Error> {
+		try!(self.sink.write_i64::<BigEndian>(n));
+		Ok(())
+	}
+
+
+	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Result<(), Error> {
+		try!(self.write_u64(vec.len() as u64));
+		try!(self.sink.write_all(vec));
+		Ok(())
+	}
+
+	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Result<(), Error> {
 		let bs = b32.as_fixed_bytes();
-		self.sink.write_all(bs).err().map(Error::IOErr)
+		try!(self.sink.write_all(bs));
+		Ok(())
 	}
 }
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -21,7 +21,7 @@
 
 use std::{error, fmt};
 use std::io::{self, Write, Read};
-use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian};
+use byteorder::{ByteOrder, ReadBytesExt, BigEndian};
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Debug)]
@@ -85,21 +85,48 @@ pub trait AsFixedBytes {
 /// written to an underlying stream or container (depending on implementation).
 pub trait Writer {
 	/// Writes a u8 as bytes
-	fn write_u8(&mut self, n: u8) -> Result<(), Error>;
+	fn write_u8(&mut self, n: u8) -> Result<(), Error> {
+		self.write_fixed_bytes(&[n])
+	}
+
 	/// Writes a u16 as bytes
-	fn write_u16(&mut self, n: u16) -> Result<(), Error>;
+	fn write_u16(&mut self, n: u16) -> Result<(), Error> {
+		let mut bytes = [0; 2];
+		BigEndian::write_u16(&mut bytes, n);
+		self.write_fixed_bytes(&bytes)
+	}
+
 	/// Writes a u32 as bytes
-	fn write_u32(&mut self, n: u32) -> Result<(), Error>;
+	fn write_u32(&mut self, n: u32) -> Result<(), Error> {
+		let mut bytes = [0; 4];
+		BigEndian::write_u32(&mut bytes, n);
+		self.write_fixed_bytes(&bytes)
+	}
+
 	/// Writes a u64 as bytes
-	fn write_u64(&mut self, n: u64) -> Result<(), Error>;
+	fn write_u64(&mut self, n: u64) -> Result<(), Error> {
+		let mut bytes = [0; 8];
+		BigEndian::write_u64(&mut bytes, n);
+		self.write_fixed_bytes(&bytes)
+	}
+
 	/// Writes a i64 as bytes
-	fn write_i64(&mut self, n: i64) -> Result<(), Error>;
-	/// Writes a variable length `Vec`, the length of the `Vec` is encoded as a
+	fn write_i64(&mut self, n: i64) -> Result<(), Error> {
+		let mut bytes = [0; 8];
+		BigEndian::write_i64(&mut bytes, n);
+		self.write_fixed_bytes(&bytes)
+	}
+
+	/// Writes a variable number of bytes. The length is encoded as a 64-bit
 	/// prefix.
-	fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error>;
+	fn write_bytes(&mut self, bytes: &AsFixedBytes) -> Result<(), Error> {
+		try!(self.write_u64(bytes.as_fixed_bytes().len() as u64));
+		self.write_fixed_bytes(bytes)
+	}
+
 	/// Writes a fixed number of bytes from something that can turn itself into
 	/// a `&[u8]`. The reader is expected to know the actual length on read.
-	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Result<(), Error>;
+	fn write_fixed_bytes(&mut self, fixed: &AsFixedBytes) -> Result<(), Error>;
 }
 
 /// Implementations defined how different numbers and binary structures are
@@ -225,38 +252,8 @@ struct BinWriter<'a> {
 }
 
 impl<'a> Writer for BinWriter<'a> {
-	fn write_u8(&mut self, n: u8) -> Result<(), Error> {
-		try!(self.sink.write_u8(n));
-		Ok(())
-	}
-	fn write_u16(&mut self, n: u16) -> Result<(), Error> {
-		try!(self.sink.write_u16::<BigEndian>(n));
-		Ok(())
-	}
-	fn write_u32(&mut self, n: u32) -> Result<(), Error> {
-		try!(self.sink.write_u32::<BigEndian>(n));
-		Ok(())
-	}
-
-	fn write_u64(&mut self, n: u64) -> Result<(), Error> {
-		try!(self.sink.write_u64::<BigEndian>(n));
-		Ok(())
-	}
-
-	fn write_i64(&mut self, n: i64) -> Result<(), Error> {
-		try!(self.sink.write_i64::<BigEndian>(n));
-		Ok(())
-	}
-
-
-	fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
-		try!(self.write_u64(data.len() as u64));
-		try!(self.sink.write_all(data));
-		Ok(())
-	}
-
-	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Result<(), Error> {
-		let bs = b32.as_fixed_bytes();
+	fn write_fixed_bytes(&mut self, fixed: &AsFixedBytes) -> Result<(), Error> {
+		let bs = fixed.as_fixed_bytes();
 		try!(self.sink.write_all(bs));
 		Ok(())
 	}
@@ -276,6 +273,16 @@ impl_slice_bytes!(::secp::key::SecretKey);
 impl_slice_bytes!(::secp::Signature);
 impl_slice_bytes!(::secp::pedersen::Commitment);
 impl_slice_bytes!(Vec<u8>);
+impl_slice_bytes!([u8; 1]);
+impl_slice_bytes!([u8; 2]);
+impl_slice_bytes!([u8; 4]);
+impl_slice_bytes!([u8; 8]);
+
+impl<'a> AsFixedBytes for &'a [u8] {
+	fn as_fixed_bytes(&self) -> &[u8] {
+		*self
+	}
+}
 
 impl AsFixedBytes for ::core::hash::Hash {
 	fn as_fixed_bytes(&self) -> &[u8] {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -96,7 +96,7 @@ pub trait Writer {
 	fn write_i64(&mut self, n: i64) -> Result<(), Error>;
 	/// Writes a variable length `Vec`, the length of the `Vec` is encoded as a
 	/// prefix.
-	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Result<(), Error>;
+	fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error>;
 	/// Writes a fixed number of bytes from something that can turn itself into
 	/// a `&[u8]`. The reader is expected to know the actual length on read.
 	fn write_fixed_bytes(&mut self, b32: &AsFixedBytes) -> Result<(), Error>;
@@ -249,9 +249,9 @@ impl<'a> Writer for BinWriter<'a> {
 	}
 
 
-	fn write_vec(&mut self, vec: &mut Vec<u8>) -> Result<(), Error> {
-		try!(self.write_u64(vec.len() as u64));
-		try!(self.sink.write_all(vec));
+	fn write_bytes(&mut self, data: &[u8]) -> Result<(), Error> {
+		try!(self.write_u64(data.len() as u64));
+		try!(self.sink.write_all(data));
 		Ok(())
 	}
 

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -51,19 +51,15 @@ impl Handshake {
 		// send the first part of the handshake
 		let sender_addr = conn.local_addr().unwrap();
 		let receiver_addr = conn.peer_addr().unwrap();
-		let opt_err = serialize(&mut conn,
-		                        &Hand {
-			                        version: PROTOCOL_VERSION,
-			                        capabilities: FULL_SYNC,
-			                        nonce: nonce,
-			                        sender_addr: SockAddr(sender_addr),
-			                        receiver_addr: SockAddr(receiver_addr),
-			                        user_agent: USER_AGENT.to_string(),
-		                        });
-		match opt_err {
-			Some(err) => return Err(err),
-			None => {}
-		}
+		try!(serialize(&mut conn,
+		               &Hand {
+			               version: PROTOCOL_VERSION,
+			               capabilities: FULL_SYNC,
+			               nonce: nonce,
+			               sender_addr: SockAddr(sender_addr),
+			               receiver_addr: SockAddr(receiver_addr),
+			               user_agent: USER_AGENT.to_string(),
+		               }));
 
 		// deserialize the handshake response and do version negotiation
 		let shake = try!(deserialize::<Shake>(&mut conn));
@@ -127,16 +123,12 @@ impl Handshake {
 		};
 
 		// send our reply with our info
-		let opt_err = serialize(&mut conn,
-		                        &Shake {
-			                        version: PROTOCOL_VERSION,
-			                        capabilities: FULL_SYNC,
-			                        user_agent: USER_AGENT.to_string(),
-		                        });
-		match opt_err {
-			Some(err) => return Err(err),
-			None => {}
-		}
+		try!(serialize(&mut conn,
+		               &Shake {
+			               version: PROTOCOL_VERSION,
+			               capabilities: FULL_SYNC,
+			               user_agent: USER_AGENT.to_string(),
+		               }));
 
 		info!("Received connection from peer {:?}", peer_info);
 		// when more than one protocol version is supported, choosing should go here


### PR DESCRIPTION
Clean up the `Hashed` trait so that it does not require allocation anywhere; also make it reuse the `Writeable` trait where this is available. Add a `SerializationMode` property to `Writer` which signals whether or not witness data should be serialized. Replace `Option<Error>` with `Result<(), Error>` in core/ser.rs.

Sorry for these large PRs with no visible changes, but I'm working on cleaning up Merklization and I keep bumping into these problems.