### PR TITLE
Safer serializations

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -29,7 +29,7 @@ pub const REWARD: u64 = 1_000_000_000;
 pub const BLOCK_TIME_SEC: u8 = 30;
 
 /// Cuckoo-cycle proof size (cycle length)
-pub const PROOFSIZE: usize = 42;
+pub const POWSIZE: usize = 42;
 
 /// Default Cuckoo Cycle size shift used is 28. We may decide to increase it
 /// when hashrate increases. May also start lower.
@@ -47,7 +47,7 @@ pub const EASINESS: u32 = 50;
 pub const CUT_THROUGH_HORIZON: u32 = 48 * 3600 / (BLOCK_TIME_SEC as u32);
 
 /// Max target hash, lowest difficulty
-pub const MAX_TARGET: [u32; PROOFSIZE] =
+pub const MAX_TARGET: [u32; POWSIZE] =
 	[0xfff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
 	 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
 	 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -116,10 +116,10 @@ impl Readable<Block> for Block {
 	fn read(reader: &mut Reader) -> Result<Block, ser::Error> {
 		let (height, previous, timestamp, utxo_merkle, tx_merkle, nonce) = ser_multiread!(reader,
 			               read_u64,
-			               read_32_bytes,
+			               read_hash,
 			               read_i64,
-			               read_32_bytes,
-			               read_32_bytes,
+			               read_hash,
+			               read_hash,
 			               read_u64);
 
 		// cuckoo cycle of 42 nodes
@@ -143,14 +143,14 @@ impl Readable<Block> for Block {
 		Ok(Block {
 			header: BlockHeader {
 				height: height,
-				previous: Hash::from_vec(previous),
+				previous: previous,
 				timestamp: time::at_utc(time::Timespec {
 					sec: timestamp,
 					nsec: 0,
 				}),
 				td: td,
-				utxo_merkle: Hash::from_vec(utxo_merkle),
-				tx_merkle: Hash::from_vec(tx_merkle),
+				utxo_merkle: utxo_merkle,
+				tx_merkle: tx_merkle,
 				pow: Proof(pow),
 				nonce: nonce,
 			},

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -333,7 +333,7 @@ impl Block {
 	fn reward_output(skey: secp::key::SecretKey,
 	                 secp: &Secp256k1)
 	                 -> Result<(Output, TxProof), secp::Error> {
-		let msg = try!(secp::Message::from_slice(&[0; 32]));
+		let msg = try!(secp::Message::from_slice(&[0u8; secp::constants::MESSAGE_SIZE]));
 		let sig = try!(secp.sign(&msg, &skey));
 		let output = Output::OvertOutput {
 				value: REWARD,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -23,7 +23,7 @@ use std::collections::HashSet;
 use core::Committed;
 use core::{Input, Output, Proof, TxProof, Transaction};
 use core::transaction::merkle_inputs_outputs;
-use consensus::{PROOFSIZE, REWARD, MAX_IN_OUT_LEN};
+use consensus::{REWARD, MAX_IN_OUT_LEN};
 use core::hash::{Hash, Hashed, ZERO_HASH};
 use ser::{self, Readable, Reader, Writeable, Writer};
 
@@ -67,10 +67,7 @@ impl Writeable for BlockHeader {
 		// make sure to not introduce any variable length data before the nonce to
 		// avoid complicating PoW
 		try!(writer.write_u64(self.nonce));
-		// cuckoo cycle of 42 nodes
-		for n in 0..42 {
-			try!(writer.write_u32(self.pow.0[n]));
-		}
+		try!(writer.write_pow(self.pow));
 		writer.write_u64(self.td)
 	}
 }
@@ -114,19 +111,14 @@ impl Writeable for Block {
 /// from a binary stream.
 impl Readable<Block> for Block {
 	fn read(reader: &mut Reader) -> Result<Block, ser::Error> {
-		let (height, previous, timestamp, utxo_merkle, tx_merkle, nonce) = ser_multiread!(reader,
+		let (height, previous, timestamp, utxo_merkle, tx_merkle, nonce, pow) = ser_multiread!(reader,
 			               read_u64,
 			               read_hash,
 			               read_i64,
 			               read_hash,
 			               read_hash,
-			               read_u64);
-
-		// cuckoo cycle of 42 nodes
-		let mut pow = [0; PROOFSIZE];
-		for n in 0..PROOFSIZE {
-			pow[n] = try!(reader.read_u32());
-		}
+			               read_u64,
+			               read_pow);
 
 		let (td, input_len, output_len, proof_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64, read_u64);
@@ -151,7 +143,7 @@ impl Readable<Block> for Block {
 				td: td,
 				utxo_merkle: utxo_merkle,
 				tx_merkle: tx_merkle,
-				pow: Proof(pow),
+				pow: pow,
 				nonce: nonce,
 			},
 			inputs: inputs,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -21,7 +21,7 @@ use secp::key::SecretKey;
 use std::collections::HashSet;
 
 use core::Committed;
-use core::{Input, Output, Proof, TxProof, Transaction};
+use core::{Input, Output, POW, TxProof, Transaction};
 use core::transaction::merkle_inputs_outputs;
 use consensus::{REWARD, MAX_IN_OUT_LEN};
 use core::hash::{Hash, Hashed, ZERO_HASH};
@@ -36,7 +36,7 @@ pub struct BlockHeader {
 	pub utxo_merkle: Hash,
 	pub tx_merkle: Hash,
 	pub nonce: u64,
-	pub pow: Proof,
+	pub pow: POW,
 }
 
 impl Default for BlockHeader {
@@ -49,7 +49,7 @@ impl Default for BlockHeader {
 			utxo_merkle: ZERO_HASH,
 			tx_merkle: ZERO_HASH,
 			nonce: 0,
-			pow: Proof::zero(),
+			pow: POW::zero(),
 		}
 	}
 }

--- a/core/src/core/hash.rs
+++ b/core/src/core/hash.rs
@@ -38,14 +38,6 @@ impl fmt::Display for Hash {
 }
 
 impl Hash {
-	/// Creates a new hash from a vector
-	pub fn from_vec(v: Vec<u8>) -> Hash {
-		let mut a = [0; 32];
-		for i in 0..a.len() {
-			a[i] = v[i];
-		}
-		Hash(a)
-	}
 	/// Converts the hash to a byte vector
 	pub fn to_vec(&self) -> Vec<u8> {
 		self.0.to_vec()
@@ -56,7 +48,7 @@ impl Hash {
 	}
 }
 
-pub const ZERO_HASH: Hash = Hash([0; 32]);
+pub const ZERO_HASH: Hash = Hash([0u8; 32]);
 
 /// Serializer that outputs a hash of the serialized object
 pub struct HashWriter {
@@ -95,7 +87,7 @@ impl<W: ser::Writeable> Hashed for W {
 	fn hash(&self) -> Hash {
 		let mut hasher = HashWriter::default();
 		ser::Writeable::write(self, &mut hasher).unwrap();
-		let mut ret = [0; 32];
+		let mut ret = [0u8; 32];
 		hasher.finalize(&mut ret);
 		Hash(ret)
 	}
@@ -104,7 +96,7 @@ impl<W: ser::Writeable> Hashed for W {
 impl Hashed for [u8] {
 	fn hash(&self) -> Hash {
 		let mut hasher = HashWriter::default();
-		let mut ret = [0; 32];
+		let mut ret = [0u8; 32];
 		ser::Writer::write_bytes(&mut hasher, &self).unwrap();
 		hasher.finalize(&mut ret);
 		Hash(ret)

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -25,7 +25,7 @@ use std::cmp::Ordering;
 use secp::{self, Secp256k1};
 use secp::pedersen::*;
 
-use consensus::PROOFSIZE;
+use consensus::POWSIZE;
 pub use self::block::{Block, BlockHeader};
 pub use self::transaction::{Transaction, Input, Output, TxProof};
 use self::hash::{Hash, Hashed, ZERO_HASH};
@@ -77,54 +77,54 @@ pub trait Committed {
 
 /// Proof of work
 #[derive(Copy)]
-pub struct Proof(pub [u32; PROOFSIZE]);
+pub struct POW(pub [u32; POWSIZE]);
 
-impl fmt::Debug for Proof {
+impl fmt::Debug for POW {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		try!(write!(f, "Cuckoo("));
 		for (i, val) in self.0[..].iter().enumerate() {
 			try!(write!(f, "{:x}", val));
-			if i < PROOFSIZE - 1 {
+			if i < POWSIZE - 1 {
 				write!(f, " ");
 			}
 		}
 		write!(f, ")")
 	}
 }
-impl PartialOrd for Proof {
-	fn partial_cmp(&self, other: &Proof) -> Option<Ordering> {
+impl PartialOrd for POW {
+	fn partial_cmp(&self, other: &POW) -> Option<Ordering> {
 		self.0.partial_cmp(&other.0)
 	}
 }
-impl PartialEq for Proof {
-	fn eq(&self, other: &Proof) -> bool {
+impl PartialEq for POW {
+	fn eq(&self, other: &POW) -> bool {
 		self.0[..] == other.0[..]
 	}
 }
-impl Eq for Proof {}
-impl Clone for Proof {
-	fn clone(&self) -> Proof {
+impl Eq for POW {}
+impl Clone for POW {
+	fn clone(&self) -> POW {
 		*self
 	}
 }
 
-impl Proof {
+impl POW {
 	/// Builds a proof with all bytes zeroed out
-	pub fn zero() -> Proof {
-		Proof([0; PROOFSIZE])
+	pub fn zero() -> POW {
+		POW([0; POWSIZE])
 	}
 	/// Builds a proof from a vector of exactly PROOFSIZE
-	pub fn from_vec(v: Vec<u32>) -> Proof {
-		assert!(v.len() == PROOFSIZE);
-		let mut p = [0; PROOFSIZE];
+	pub fn from_vec(v: Vec<u32>) -> POW {
+		assert!(v.len() == POWSIZE);
+		let mut p = [0; POWSIZE];
 		for (n, elem) in v.iter().enumerate() {
 			p[n] = *elem;
 		}
-		Proof(p)
+		POW(p)
 	}
 	/// Converts the proof to a vector of u64s
 	pub fn to_u64s(&self) -> Vec<u64> {
-		let mut nonces = Vec::with_capacity(PROOFSIZE);
+		let mut nonces = Vec::with_capacity(POWSIZE);
 		for n in self.0.iter() {
 			nonces.push(*n as u64);
 		}

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -111,16 +111,7 @@ impl Clone for POW {
 impl POW {
 	/// Builds a proof with all bytes zeroed out
 	pub fn zero() -> POW {
-		POW([0; POWSIZE])
-	}
-	/// Builds a proof from a vector of exactly PROOFSIZE
-	pub fn from_vec(v: Vec<u32>) -> POW {
-		assert!(v.len() == POWSIZE);
-		let mut p = [0; POWSIZE];
-		for (n, elem) in v.iter().enumerate() {
-			p[n] = *elem;
-		}
-		POW(p)
+		POW([0u32; POWSIZE])
 	}
 	/// Converts the proof to a vector of u64s
 	pub fn to_u64s(&self) -> Vec<u64> {

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -111,9 +111,9 @@ impl Clone for Proof {
 impl Proof {
 	/// Builds a proof with all bytes zeroed out
 	pub fn zero() -> Proof {
-		Proof([0; 42])
+		Proof([0; PROOFSIZE])
 	}
-	/// Builds a proof from a vector of exactly PROOFSIZE (42) u32.
+	/// Builds a proof from a vector of exactly PROOFSIZE
 	pub fn from_vec(v: Vec<u32>) -> Proof {
 		assert!(v.len() == PROOFSIZE);
 		let mut p = [0; PROOFSIZE];

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -263,8 +263,8 @@ impl Writeable for Input {
 /// an Input from a binary stream.
 impl Readable<Input> for Input {
 	fn read(reader: &mut Reader) -> Result<Input, ser::Error> {
-		reader.read_fixed_bytes(32)
-			.map(|h| Input::BareInput { output: Hash::from_vec(h) })
+		reader.read_hash()
+			.map(|h| Input::BareInput { output: h })
 	}
 }
 

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -36,7 +36,7 @@ pub fn genesis() -> core::Block {
 			utxo_merkle: [0u8; 32].hash(),
 			tx_merkle: [0u8; 32].hash(),
 			nonce: 0,
-			pow: core::Proof::zero(), // TODO get actual PoW solution
+			pow: core::POW::zero(), // TODO get actual PoW solution
 		},
 		inputs: vec![],
 		outputs: vec![],

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -17,21 +17,15 @@
 use time;
 
 use core;
-
-use tiny_keccak::Keccak;
+use core::hash::Hashed;
 
 // Genesis block definition. It has no rewards, no inputs, no outputs, no
 // fees and a height of zero.
 pub fn genesis() -> core::Block {
-	let mut sha3 = Keccak::new_sha3_256();
-	let mut empty_h = [0; 32];
-	sha3.update(&[]);
-	sha3.finalize(&mut empty_h);
-
 	core::Block {
 		header: core::BlockHeader {
 			height: 0,
-			previous: core::hash::Hash([0xff; 32]),
+			previous: core::hash::Hash([0xffu8; 32]),
 			timestamp: time::Tm {
 				tm_year: 1997,
 				tm_mon: 7,
@@ -39,8 +33,8 @@ pub fn genesis() -> core::Block {
 				..time::empty_tm()
 			},
 			td: 0,
-			utxo_merkle: core::hash::Hash::from_vec(empty_h.to_vec()),
-			tx_merkle: core::hash::Hash::from_vec(empty_h.to_vec()),
+			utxo_merkle: [0u8; 32].hash(),
+			tx_merkle: [0u8; 32].hash(),
 			nonce: 0,
 			pow: core::Proof::zero(), // TODO get actual PoW solution
 		},

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -28,7 +28,7 @@ mod cuckoo;
 use time;
 
 use consensus::{SIZESHIFT, EASINESS};
-use core::{Block, Proof};
+use core::{Block, POW};
 use core::hash::{Hash, Hashed};
 use pow::cuckoo::{Cuckoo, Miner, Error};
 
@@ -87,17 +87,17 @@ impl PowHeader {
 }
 
 /// Validates the proof of work of a given header.
-pub fn verify(b: &Block, target: Proof) -> bool {
+pub fn verify(b: &Block, target: POW) -> bool {
 	verify_size(b, target, SIZESHIFT)
 }
 
 /// Same as default verify function but uses the much easier Cuckoo20 (mostly
 /// for tests).
-pub fn verify20(b: &Block, target: Proof) -> bool {
+pub fn verify20(b: &Block, target: POW) -> bool {
 	verify_size(b, target, 20)
 }
 
-pub fn verify_size(b: &Block, target: Proof, sizeshift: u32) -> bool {
+pub fn verify_size(b: &Block, target: POW, sizeshift: u32) -> bool {
 	let hash = PowHeader::from_block(b).hash();
 	// make sure the hash is smaller than our target before going into more
 	// expensive validation
@@ -110,17 +110,17 @@ pub fn verify_size(b: &Block, target: Proof, sizeshift: u32) -> bool {
 /// Runs a naive single-threaded proof of work computation over the provided
 /// block, until the required difficulty target is reached. May take a
 /// while for a low target...
-pub fn pow(b: &Block, target: Proof) -> Result<(Proof, u64), Error> {
+pub fn pow(b: &Block, target: POW) -> Result<(POW, u64), Error> {
 	pow_size(b, target, SIZESHIFT)
 }
 
 /// Same as default pow function but uses the much easier Cuckoo20 (mostly for
 /// tests).
-pub fn pow20(b: &Block, target: Proof) -> Result<(Proof, u64), Error> {
+pub fn pow20(b: &Block, target: POW) -> Result<(POW, u64), Error> {
 	pow_size(b, target, 20)
 }
 
-fn pow_size(b: &Block, target: Proof, sizeshift: u32) -> Result<(Proof, u64), Error> {
+fn pow_size(b: &Block, target: POW, sizeshift: u32) -> Result<(POW, u64), Error> {
 	let mut pow_header = PowHeader::from_block(b);
 	let start_nonce = pow_header.nonce;
 
@@ -153,17 +153,17 @@ fn pow_size(b: &Block, target: Proof, sizeshift: u32) -> Result<(Proof, u64), Er
 mod test {
 	use super::*;
 	use consensus::MAX_TARGET;
-	use core::Proof;
+	use core::POW;
 	use genesis;
 
 	#[test]
 	fn genesis_pow() {
 		let mut b = genesis::genesis();
-		let (proof, nonce) = pow20(&b, Proof(MAX_TARGET)).unwrap();
+		let (proof, nonce) = pow20(&b, POW(MAX_TARGET)).unwrap();
 		assert!(nonce > 0);
-		assert!(proof < Proof(MAX_TARGET));
+		assert!(proof < POW(MAX_TARGET));
 		b.header.pow = proof;
 		b.header.nonce = nonce;
-		assert!(verify20(&b, Proof(MAX_TARGET)));
+		assert!(verify20(&b, POW(MAX_TARGET)));
 	}
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -23,8 +23,8 @@ use std::{error, fmt};
 use std::io::{self, Write, Read};
 use byteorder::{ByteOrder, ReadBytesExt, BigEndian};
 use core::hash::Hash;
-use core::Proof;
-use consensus::PROOFSIZE;
+use core::POW;
+use consensus::POWSIZE;
 
 /// Possible errors deriving from serializing or deserializing.
 #[derive(Debug)]
@@ -148,8 +148,9 @@ pub trait Writer {
 	/// a `&[u8]`. The reader is expected to know the actual length on read.
 	fn write_fixed_bytes(&mut self, fixed: &AsFixedBytes) -> Result<(), Error>;
 
-	fn write_pow(&mut self, pow: Proof) -> Result<(), Error> {
-		for n in 0..PROOFSIZE {
+	/// Writes a POW
+	fn write_pow(&mut self, pow: POW) -> Result<(), Error> {
+		for n in 0..POWSIZE {
 			try!(self.write_u32(pow.0[n]));
 		}
 		Ok(())
@@ -175,8 +176,8 @@ pub trait Reader {
 	fn read_fixed_bytes(&mut self, length: usize) -> Result<Vec<u8>, Error>;
 	/// Convenience function to read a hash
 	fn read_hash(&mut self) -> Result<Hash, Error>;
-	/// Convinience function to read a proof
-	fn read_pow(&mut self) -> Result<Proof, Error>;
+	/// Convinience function to read a POW
+	fn read_pow(&mut self) -> Result<POW, Error>;
 	/// Convenience function to read 33 fixed bytes
 	fn read_33_bytes(&mut self) -> Result<Vec<u8>, Error>;
 	/// Consumes a byte from the reader, producing an error if it doesn't have
@@ -263,12 +264,12 @@ impl<'a> Reader for BinReader<'a> {
 		}
 		Ok(Hash(a))
 	}
-	fn read_pow(&mut self) -> Result<Proof, Error> {
-		let mut pow = [0u32; PROOFSIZE];
-		for n in 0..PROOFSIZE {
+	fn read_pow(&mut self) -> Result<POW, Error> {
+		let mut pow = [0u32; POWSIZE];
+		for n in 0..POWSIZE {
 			pow[n] = try!(self.read_u32());
 		}
-		Ok(Proof(pow))
+		Ok(POW(pow))
 	}
 	fn read_33_bytes(&mut self) -> Result<Vec<u8>, Error> {
 		self.read_fixed_bytes(33)


### PR DESCRIPTION
Removed Hash::from_vec as it was working with any length of vec, creating ambiguity. Instead introduced read_hash to avoid the need for repeated conversion of vec to Hash. Used Hashed trait instead of repeating hash algorithm. 

Renamed Proof to POW. Removed POW::from_vec for similar reasons. introduced read_pow and write_pow.

I am not sure [0; x] is interchangeable with [0u8; x]. made explicit to be on the safe side.

what is read_33_bytes for?