### PR TITLE
Fix error[E0243]: wrong number of type arguments

### DIFF
--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -258,7 +258,7 @@ mod test {
 			vec![Method::Get]
 		}
 
-		fn get(&self, name: String) -> Result<Animal> {
+		fn get(&self, name: String) -> ApiResult<Animal> {
 			Ok(Animal {
 				name: name,
 				legs: 4,


### PR DESCRIPTION
Change Result<Animal> to be ApiResult<Animal>