### PR TITLE
secp256k1zkp:  Fix several warnings from implicitly declared function…

### DIFF
--- a/secp256k1zkp/depend/secp256k1-zkp/src/ecmult_gen_impl.h
+++ b/secp256k1zkp/depend/secp256k1-zkp/src/ecmult_gen_impl.h
@@ -14,6 +14,9 @@
 #ifdef USE_ECMULT_STATIC_PRECOMPUTATION
 #include "ecmult_static_context.h"
 #endif
+
+#include <string.h>
+
 static void secp256k1_ecmult_gen_context_init(secp256k1_ecmult_gen_context *ctx) {
     ctx->prec = NULL;
 }

--- a/secp256k1zkp/depend/secp256k1-zkp/src/ecmult_impl.h
+++ b/secp256k1zkp/depend/secp256k1-zkp/src/ecmult_impl.h
@@ -11,6 +11,8 @@
 #include "scalar.h"
 #include "ecmult.h"
 
+#include <string.h>
+
 /* optimal for 128-bit and 256-bit exponents. */
 #define WINDOW_A 5
 


### PR DESCRIPTION
… 'memcpy'

Added includes for <string.h> to explicitly declare 'memcpy' where needed.

This message is typical of messages suppressed by declaring 'memcpy':

    warning: In file included from depend/secp256k1-zkp/src/secp256k1.c:14:0:
    warning: depend/secp256k1-zkp/src/ecmult_impl.h: In function ‘secp256k1_ecmult_context_clone’:
    warning: depend/secp256k1-zkp/src/ecmult_impl.h:186:9: warning: implicit declaration of function ‘memcpy’ [-Wimplicit-function-declaration]
    warning:          memcpy(dst->pre_g, src->pre_g, size);
    warning:          ^~~~~~