### PR TITLE
Testing Framework [WIP] and new command line options to configure wallet ports and directories

### DIFF
--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -12,6 +12,7 @@ grin_store = { path = "../store" }
 grin_p2p = { path = "../p2p" }
 grin_pool = { path = "../pool" }
 grin_util = { path = "../util" }
+grin_wallet = { path = "../wallet" }
 secp256k1zkp = { path = "../secp256k1zkp" }
 
 env_logger="^0.3.5"
@@ -25,3 +26,4 @@ serde_derive = "~1.0.8"
 tokio-core="^0.1.1"
 tokio-timer="^0.1.0"
 rand = "^0.3"
+tiny-keccak = "1.1"

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -168,7 +168,6 @@ impl Miner {
 			let skey = secp::key::SecretKey::new(&secp_inst, &mut rng);
 			core::Block::reward_output(skey, &secp_inst).unwrap()
 		} else {
-			println!("wallet receiver url: {}", self.config.wallet_receiver_url.as_str());
 			let url = format!("{}/v1/receive/coinbase",
 			                  self.config.wallet_receiver_url.as_str());
 			let res: CbData = api::client::post(url.as_str(),

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -168,6 +168,7 @@ impl Miner {
 			let skey = secp::key::SecretKey::new(&secp_inst, &mut rng);
 			core::Block::reward_output(skey, &secp_inst).unwrap()
 		} else {
+			println!("wallet receiver url: {}", self.config.wallet_receiver_url.as_str());
 			let url = format!("{}/v1/receive/coinbase",
 			                  self.config.wallet_receiver_url.as_str());
 			let res: CbData = api::client::post(url.as_str(),

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -44,7 +44,7 @@ use tiny_keccak::Keccak;
 use wallet::WalletConfig;
 
 
-/// Errors that can be returned by an ApiEndpoint implementation.
+/// Errors that can be returned by LocalServerContainer
 #[derive(Debug)]
 pub enum Error {
 	Internal(String),
@@ -202,10 +202,11 @@ impl LocalServerContainerPool {
         }
     }
 
-    /// Starts all servers, with or without mining
+    ///Starts all servers, with or without mining
+    ///TODO: This should accept a closure so tests can determine what 
+    ///to do when the run is finished
 
     pub fn start_all_servers(&mut self) {
-        
         
         for s in &mut self.server_containers {
             let mut wallet_url = String::from("http://localhost:13416");
@@ -255,8 +256,11 @@ impl LocalServerContainerPool {
 
 }
 
+/// Just exercises the structures above, creates 5 servers, all starting wallets,
+/// mining and connecting to each other in their own directories
+
 #[test]
-fn simulate_much_mining(){
+fn simulate_parallel_miners(){
     env_logger::init();
     let num_servers=5;
     
@@ -267,12 +271,7 @@ fn simulate_much_mining(){
 
     server_pool.connect_all_peers();
     server_pool.start_all_servers();
-
-    panic!("marp");
-  
 }
-
-
 
 /// Create a network of 5 servers and mine a block, verifying that the block
 /// gets propagated to all.

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -152,9 +152,9 @@ impl LocalServerContainerPool {
       Ok((LocalServerContainerPool{
         event_loop: evtlp, 
         base_http_addr : String::from("0.0.0.0"),
-        base_port_server: 10000,
-        base_port_api: 20000,
-        base_port_wallet: 30000,
+        base_port_server: 15000,
+        base_port_api: 16000,
+        base_port_wallet: 17000,
         server_containers: servers,
       }))
     }

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -16,6 +16,10 @@ extern crate grin_grin as grin;
 extern crate grin_core as core;
 extern crate grin_p2p as p2p;
 extern crate grin_chain as chain;
+extern crate grin_api as api;
+extern crate grin_wallet as wallet;
+extern crate secp256k1zkp as secp;
+extern crate tiny_keccak;
 
 extern crate env_logger;
 extern crate futures;
@@ -26,11 +30,19 @@ use std::io;
 use std::thread;
 use std::time;
 use std::default::Default;
+use std::mem;
 
 use futures::{Future, Poll, Async};
 use futures::task::park;
 use tokio_core::reactor;
 use tokio_timer::Timer;
+
+use secp::Secp256k1;
+use secp::key::SecretKey;
+use tiny_keccak::Keccak;
+
+use wallet::WalletConfig;
+
 
 /// Errors that can be returned by an ApiEndpoint implementation.
 #[derive(Debug)]
@@ -44,18 +56,25 @@ pub enum Error {
 /// on a server, i.e. server, wallet in send or recieve mode
 
 struct LocalServerContainer {
+    pub working_dir: String,
     pub server : grin::Server,
 
     pub enable_mining: bool,
     pub enable_wallet: bool,
+
+    pub wallet_port: u16,
+    wallet_is_running: bool,
+
+    apis: api::ApiServer,
 }
 
 impl LocalServerContainer {
     pub fn new(api_addr:String, server_port: u16, event_loop: &reactor::Core) -> Result<LocalServerContainer, Error> {
+      let working_dir = format!("target/test_servers/server-{}", server_port);
       let mut s = grin::Server::future(
             grin::ServerConfig{
                 api_http_addr: api_addr,
-                db_root: format!("target/test_servers/server-{}/grin-prop", server_port),
+                db_root: format!("{}/grin-prop", working_dir),
                 cuckoo_size: 12,
                 p2p_config: p2p::P2PConfig{port: server_port, ..p2p::P2PConfig::default()},
                 ..Default::default()
@@ -64,7 +83,54 @@ impl LocalServerContainer {
            server: s,
            enable_mining: false,
            enable_wallet: false,
+           wallet_port: 30000,
+           wallet_is_running: false,
+           working_dir: working_dir,
+
+           apis: api::ApiServer::new("/v1".to_string()),
        }))
+    }
+
+    /// Starts a wallet daemon to receive and returns the
+    /// listening server url
+
+    pub fn start_wallet(&mut self) -> String {
+      
+        //Just use the server address and port number for the wallet seed now
+      	let url = format!("{}:{}", self.server.config.p2p_config.host,
+                                       self.wallet_port);
+
+	      let mut sha3 = Keccak::new_sha3_256();
+	      sha3.update(url.as_bytes());
+	      let mut seed = [0; 32];
+	      sha3.finalize(&mut seed);
+
+	      let s = Secp256k1::new();
+	      let key = wallet::ExtendedKey::from_seed(&s, &seed[..])
+		         .expect("Error deriving extended key from seed.");
+        
+        println!("Starting the Grin wallet receiving daemon on {} ", self.wallet_port );
+
+        let mut wallet_config = WalletConfig::default();
+        wallet_config.data_file_dir=self.working_dir.clone();
+			  
+			  self.apis.register_endpoint("/receive".to_string(), wallet::WalletReceiver { 
+          key: key,
+          config: wallet_config,
+        });
+
+        let return_url = url.clone();
+			  self.apis.start(url).unwrap_or_else(|e| {
+				    println!("Failed to start Grin wallet receiver: {}.", e);
+			  });
+
+        self.wallet_is_running = true;
+        return return_url;
+    }
+
+    /// Stops the wallet daemon
+    pub fn stop_wallet(&mut self){
+        self.apis.stop();
     }
 }
 
@@ -74,6 +140,7 @@ struct LocalServerContainerPool {
     base_http_addr: String, 
     base_port_server: u16,
     base_port_api: u16,
+    base_port_wallet: u16,
     server_containers: Vec<LocalServerContainer>,    
 }
 
@@ -87,20 +154,26 @@ impl LocalServerContainerPool {
         base_http_addr : String::from("0.0.0.0"),
         base_port_server: 10000,
         base_port_api: 20000,
+        base_port_wallet: 30000,
         server_containers: servers,
       }))
     }
 
-    pub fn create_server(&mut self, enable_mining:bool) {
+    pub fn create_server(&mut self, enable_mining:bool, enable_wallet:bool ) {
 
         let server_port = self.base_port_server+self.server_containers.len() as u16;
         let api_port = self.base_port_api+self.server_containers.len() as u16;
 
+        
         let api_addr = format!("{}:{}", self.base_http_addr, api_port);
 
         let mut server_container = LocalServerContainer::new(api_addr, server_port, &self.event_loop).unwrap();
             
         server_container.enable_mining = enable_mining;
+        server_container.enable_wallet = enable_wallet;
+
+        //if we want to start a wallet, use this port
+        server_container.wallet_port = self.base_port_wallet+self.server_containers.len() as u16;
         
         self.server_containers.push(server_container);
     }
@@ -131,42 +204,72 @@ impl LocalServerContainerPool {
 
     /// Starts all servers, with or without mining
 
-    fn start_all_servers(&mut self) {
-        for s in &self.server_containers {
-            if s.enable_mining == true {
-               let mut miner_config = grin::MinerConfig{
+    pub fn start_all_servers(&mut self) {
+        
+        
+        for s in &mut self.server_containers {
+            let mut wallet_url = String::from("http://localhost:13416");
+            if s.enable_wallet == true {
+              wallet_url=s.start_wallet();
+              //Instead of making all sorts of changes to the api server
+              //to support futures, just going to pause this thread for 
+              //half a second for the wallet to start
+              //before continuing
+
+              thread::sleep(time::Duration::from_millis(500));
+            }
+            let mut miner_config = grin::MinerConfig{
                   enable_mining: true,
                   burn_reward: true,
+                  wallet_receiver_url : format!("http://{}", wallet_url),
                   ..Default::default()
-                };
-                println!("Starting Miner on port {}", s.server.config.p2p_config.port);
+            };
+            if s.enable_wallet == true {
+                miner_config.burn_reward = false;
+            }
+            if s.enable_mining == true {
+                println!("starting Miner on port {}", s.server.config.p2p_config.port);
                 s.server.start_miner(miner_config);        
             }
+            
         }
-        self.event_loop.run(Timer::default().sleep(time::Duration::from_secs(30)).and_then(|_| {
-          //for s in self.servers {  
+
+        //borrow copy to allow access in closure
+        let mut server_containers = mem::replace(&mut self.server_containers, Vec::new());
+        //let &mut server_containers = self.server_containers;
+
+        self.event_loop.run(Timer::default().sleep(time::Duration::from_secs(60)).and_then(|_| {
+          //Stop any assocated wallet servers
+          for s in &mut server_containers {
+              if s.wallet_is_running{
+                s.stop_wallet();
+              }
+          }
+          //for s in &mut self.server_containers {  
             // occasionally 2 peers will connect to each other at the same time
             //assert!(s.peer_count() >= 4);
           //}
           Ok(())
         }));
     }
+
 }
 
 #[test]
 fn simulate_much_mining(){
-    println!("I'm here.");
+    env_logger::init();
     let num_servers=5;
     
     let mut server_pool = LocalServerContainerPool::new().unwrap();
     for n in 0..num_servers {
-        server_pool.create_server(false);
+        server_pool.create_server(true, true);
     }
 
     server_pool.connect_all_peers();
     server_pool.start_all_servers();
+
+    panic!("marp");
   
-    panic!("ouch");
 }
 
 

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -70,6 +70,11 @@ fn main() {
                      .short("m")
                      .long("mine")
                      .help("Starts the debugging mining loop"))
+				.arg(Arg::with_name("wallet_url")
+                     .short("w")
+                     .long("wallet_url")
+                     .help("A listening wallet receiver to which mining rewards will be sent")
+					 .takes_value(true))
                 .arg(Arg::with_name("config")
                      .short("c")
                      .long("config")
@@ -97,6 +102,16 @@ fn main() {
                      .long("pass")
                      .help("Wallet passphrase used to generate the private key seed")
                      .takes_value(true))
+				.arg(Arg::with_name("dir")
+                     .short("d")
+                     .long("dir")
+                     .help("Directory in which to store wallet files (defaults to current directory)")
+                     .takes_value(true))
+				.arg(Arg::with_name("port")
+                     .short("r")
+                     .long("port")
+                     .help("Port on which to run the wallet receiver when in receiver mode")
+                     .takes_value(true))	 	 
                 .subcommand(SubCommand::with_name("receive")
                             .about("Run the wallet in receiving mode. If an input file is provided, will process it, otherwise runs in server mode waiting for send requests.")
                             .arg(Arg::with_name("input")
@@ -156,6 +171,10 @@ fn server_command(server_args: &ArgMatches) {
 	if server_args.is_present("mine") {
 		server_config.mining_config.enable_mining = true;
 	}
+	if let Some(wallet_url) = server_args.value_of("wallet_url") {
+		server_config.mining_config.wallet_receiver_url = wallet_url.to_string();
+	}
+
 	if let Some(seeds) = server_args.values_of("seed") {
 		server_config.seeding_type = grin::Seeding::List(seeds.map(|s| s.to_string()).collect());
 	}
@@ -201,9 +220,19 @@ fn wallet_command(wallet_args: &ArgMatches) {
 	let key = wallet::ExtendedKey::from_seed(&s, &seed[..])
 		.expect("Error deriving extended key from seed.");
 
-	//TODO: Derive data directory and receiving port for wallet from command line?
-	let wallet_config = WalletConfig::default();
+	let default_ip = "127.0.0.1";
+	let mut addr = format!("{}:13416", default_ip);
 
+	let mut wallet_config = WalletConfig::default();
+	if let Some(port) = wallet_args.value_of("port") {
+		addr = format!("{}:{}", default_ip, port);
+		wallet_config.api_http_addr = format!("http://{}", addr).to_string();
+	}
+
+	if let Some(dir) = wallet_args.value_of("dir") {
+		wallet_config.data_file_dir = dir.to_string().clone();
+	}
+	
 	match wallet_args.subcommand() {
 		
 		("receive", Some(receive_args)) => {
@@ -213,13 +242,13 @@ fn wallet_command(wallet_args: &ArgMatches) {
 				file.read_to_string(&mut contents).expect("Unable to read transaction file.");
 				wallet::receive_json_tx(&wallet_config, &key, contents.as_str()).unwrap();
 			} else {
-				info!("Starting the Grin wallet receiving daemon...");
+				info!("Starting the Grin wallet receiving daemon at {}...", wallet_config.api_http_addr);
 				let mut apis = api::ApiServer::new("/v1".to_string());
 				apis.register_endpoint("/receive".to_string(), wallet::WalletReceiver { 
 					key: key,
 					config: wallet_config
 				});
-				apis.start("127.0.0.1:13416").unwrap_or_else(|e| {
+				apis.start(addr).unwrap_or_else(|e| {
 					error!("Failed to start Grin wallet receiver: {}.", e);
 				});
 			}

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -29,7 +29,7 @@ pub fn refresh_outputs(config: &WalletConfig, ext_key: &ExtendedKey) {
 	let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 
 	// operate within a lock on wallet data
-	WalletData::with_wallet(|wallet_data| {
+	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
 
 		// check each output that's not spent
 		for out in &mut wallet_data.outputs {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -38,3 +38,4 @@ mod types;
 pub use extkey::ExtendedKey;
 pub use receiver::{WalletReceiver, receive_json_tx};
 pub use sender::issue_send_tx;
+pub use types::WalletConfig;

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -17,6 +17,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::num;
 use std::path::Path;
+use std::path::MAIN_SEPARATOR;
 
 use serde_json;
 
@@ -78,11 +79,15 @@ impl From<api::Error> for Error {
 #[derive(Debug, Clone)]
 pub struct WalletConfig {
 	pub api_http_addr: String,
+	pub data_file_dir: String,
 }
 
 impl Default for WalletConfig {
 	fn default() -> WalletConfig {
-		WalletConfig { api_http_addr: "http://127.0.0.1:13415".to_string() }
+		WalletConfig { 
+			api_http_addr: "http://127.0.0.1:13415".to_string(),
+			data_file_dir: ".".to_string(),
+		}
 	}
 }
 
@@ -140,23 +145,26 @@ impl WalletData {
 	/// Note that due to the impossibility to do an actual file lock easily
 	/// across operating systems, this just creates a lock file with a "should
   /// not exist" option.
-	pub fn with_wallet<T, F>(f: F) -> Result<T, Error>
+	pub fn with_wallet<T, F>(data_file_dir:&str, f: F) -> Result<T, Error>
 		where F: FnOnce(&mut WalletData) -> T
 	{
+		let data_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, DAT_FILE);
+		let lock_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, LOCK_FILE);
+
 		// create the lock files, if it already exists, will produce an error
-    OpenOptions::new().write(true).create_new(true).open(LOCK_FILE).map_err(|e| {
+    	OpenOptions::new().write(true).create_new(true).open(lock_file_path).map_err(|e| {
 				Error::WalletData(format!("Could not create wallet lock file. Either \
             some other process is using the wallet or there's a write access \
             issue."))
-    })?;
+    	})?;
 
 		// do what needs to be done
-		let mut wdat = WalletData::read_or_create()?;
+		let mut wdat = WalletData::read_or_create(data_file_path)?;
 		let res = f(&mut wdat);
-		wdat.write()?;
+		wdat.write(data_file_path)?;
 
 		// delete the lock file
-		fs::remove_file(LOCK_FILE).map_err(|e| {
+		fs::remove_file(lock_file_path).map_err(|e| {
 				Error::WalletData(format!("Could not remove wallet lock file. Maybe insufficient \
 				                           rights?"))
 			})?;
@@ -165,9 +173,9 @@ impl WalletData {
 	}
 
 	/// Read the wallet data or created a brand new one if it doesn't exist yet
-	fn read_or_create() -> Result<WalletData, Error> {
-		if Path::new(DAT_FILE).exists() {
-			WalletData::read()
+	fn read_or_create(data_file_path:&str) -> Result<WalletData, Error> {
+		if Path::new(data_file_path).exists() {
+			WalletData::read(data_file_path)
 		} else {
 			// just create a new instance, it will get written afterward
 			Ok(WalletData { outputs: vec![] })
@@ -175,21 +183,21 @@ impl WalletData {
 	}
 
 	/// Read the wallet data from disk.
-	fn read() -> Result<WalletData, Error> {
-		let data_file = File::open(DAT_FILE)
-      .map_err(|e| Error::WalletData(format!("Could not open {}: {}", DAT_FILE, e)))?;
+	fn read(data_file_path:&str) -> Result<WalletData, Error> {
+		let data_file = File::open(data_file_path)
+      .map_err(|e| Error::WalletData(format!("Could not open {}: {}", data_file_path, e)))?;
 		serde_json::from_reader(data_file)
-			.map_err(|e| Error::WalletData(format!("Error reading {}: {}", DAT_FILE, e)))
+			.map_err(|e| Error::WalletData(format!("Error reading {}: {}", data_file_path, e)))
 	}
 
 	/// Write the wallet data to disk.
-	fn write(&self) -> Result<(), Error> {
-		let mut data_file = File::create(DAT_FILE)
-      .map_err(|e| Error::WalletData(format!("Could not create {}: {}", DAT_FILE, e)))?;
+	fn write(&self, data_file_path:&str) -> Result<(), Error> {
+		let mut data_file = File::create(data_file_path)
+      .map_err(|e| Error::WalletData(format!("Could not create {}: {}", data_file_path, e)))?;
 		let res_json = serde_json::to_vec_pretty(self)
       .map_err(|_| Error::WalletData(format!("Error serializing wallet data.")))?;
 		data_file.write_all(res_json.as_slice())
-			.map_err(|e| Error::WalletData(format!("Error writing {}: {}", DAT_FILE, e)))
+			.map_err(|e| Error::WalletData(format!("Error writing {}: {}", data_file_path, e)))
 	}
 
 	/// Append a new output information to the wallet data.

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -148,6 +148,11 @@ impl WalletData {
 	pub fn with_wallet<T, F>(data_file_dir:&str, f: F) -> Result<T, Error>
 		where F: FnOnce(&mut WalletData) -> T
 	{
+		//create directory if it doesn't exist
+		fs::create_dir_all(data_file_dir).unwrap_or_else(|why| {
+        	info!("! {:?}", why.kind());
+    	});
+		
 		let data_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, DAT_FILE);
 		let lock_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, LOCK_FILE);
 


### PR DESCRIPTION
While working on the testing framework in grin/tests/simulnet.rs (which is still a work-in-progress, below,) I've made a few changes in the rest of the code to better support tests running multiple servers on the same host. They reach across a few modules, so I thought I'd put them in a PR before going too much further.

Changes are:

1) Added a stop method to the rest API server, as any test running a receiving a wallet will hang indefinitely without stopping the server.
2) Modified the wallet.dat and wallet.lock files, (and the with_wallet function) to also take a directory path, and added the directory path to the WalletConfig struct. Also now require a WalletConfig to start a wallet server, and added it into a few more places so the data directory is available when needed.
3) Modified the wallet module to make the listener port configurable from the command line (via an addition to the MinerConfig structure)
4) Modified the server module to make the listening wallet for mining rewards configurable on the command line.
5) Added switches to the command line and associated help documentation.
6) Changes to the simulnet.rs tests, still a WIP

RUST_LOG=debug cargo test simulate_parallel_miners

Although a WIP, these changes can be exercised by running the simulate_parallel_miners test, which doesn't prove much at the moment, but it starts up 5 separate mining servers in 5 separate directories (under test_servers), running a separate wallet receiver for each and placing their respective wallet.dat files in the right directories.

Also considering refactoring the test framework structs (LocalServerContainer and LocalServerContainerPool) out of the grin module and somewhere accessible to all modules, perhaps in a separate module set up for running tests. Happy to discuss this further.


