### PR TITLE
Cuckoo-miner better merged into Grin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = ["api", "chain", "config", "core", "grin", "p2p", "store", "util", "po
 [dependencies]
 grin_api = { path = "./api" }
 grin_wallet = { path = "./wallet" }
+grin_grin = { path = "./grin" }
 grin_config = { path = "./config" }
 secp256k1zkp = { path = "./secp256k1zkp" }
 
@@ -20,14 +21,5 @@ serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.2"
 tiny-keccak = "1.1"
-
-[dependencies.grin_grin]
-path = "./grin"
-version = "*"
-default-features = false
-#Comment this in to use the cuckoo-miner package
-#ensure cuckoo-miner is cloned next to the 
-#grin directory
-#features = ["cuckoo_miner", "use-cuckoo-miner"]
 
 

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -19,3 +19,8 @@ secp256k1zkp = { path = "../secp256k1zkp" }
 [dev-dependencies]
 env_logger="^0.3.5"
 rand = "^0.3"
+
+#just to instantiate a mining worker during a test
+#while the miner implementation supports both 
+#cuckoo_miner and the built-in version
+grin_grin = { path = "../grin" }

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -23,10 +23,13 @@ use core::core::{Block, BlockHeader, Output};
 use core::core::target::Difficulty;
 use core::core::hash::Hash;
 use core::{consensus, genesis, pow};
+use core::pow::MiningWorker;
 use grin_store;
 use pipe;
 use store;
 use types::*;
+
+
 
 /// Helper macro to transform a Result into an Option with None in case
 /// of error
@@ -78,7 +81,8 @@ impl Chain {
 				} else {
 					consensus::DEFAULT_SIZESHIFT
 				};
-				pow::pow_size(&mut gen.header, diff, sz as u32).unwrap();
+				let mut internal_miner = pow::cuckoo::Miner::new(consensus::EASINESS, sz as u32);
+				pow::pow_size(&mut internal_miner, &mut gen.header, diff, sz as u32).unwrap();
 				chain_store.save_block(&gen)?;
 
 				// saving a new tip based on genesis

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -19,6 +19,8 @@ extern crate time;
 extern crate rand;
 extern crate secp256k1zkp as secp;
 
+extern crate grin_grin as grin;
+
 use std::sync::Arc;
 use std::thread;
 use rand::os::OsRng;
@@ -31,6 +33,11 @@ use grin_core::pow;
 use grin_core::core;
 use grin_core::consensus;
 
+use grin::{ServerConfig, MinerConfig};
+use grin::PluginMiner;
+
+use grin_core::pow::MiningWorker;
+
 #[test]
 fn mine_empty_chain() {
   env_logger::init();
@@ -41,6 +48,18 @@ fn mine_empty_chain() {
 	let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 	let reward_key = secp::key::SecretKey::new(&secp, &mut rng);
 
+	let server_config = ServerConfig::default();
+  let mut miner_config = grin::MinerConfig{
+    enable_mining: true,
+    burn_reward: true,    
+    ..Default::default()
+  };
+	miner_config.cuckoo_miner_plugin_dir = Some(String::from("../target/debug/deps"));
+
+	let mut cuckoo_miner = PluginMiner::new(consensus::EASINESS, 
+													consensus::TEST_SIZESHIFT as u32 );
+	cuckoo_miner.init(miner_config ,server_config);
+	
 	for n in 1..4 {
     let prev = chain.head_header().unwrap();
 		let mut b = core::Block::new(&prev, vec![], reward_key).unwrap();
@@ -49,7 +68,7 @@ fn mine_empty_chain() {
 		let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
 		b.header.difficulty = difficulty.clone();
 
-		pow::pow_size(&mut b.header, difficulty, consensus::TEST_SIZESHIFT as u32).unwrap();
+		pow::pow_size(&mut cuckoo_miner, &mut b.header, difficulty, consensus::TEST_SIZESHIFT as u32).unwrap();
 		chain.process_block(&b, grin_chain::EASY_POW).unwrap();
 
 		// checking our new head

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -198,9 +198,6 @@ fn test_read_config() {
         burn_reward = false
         #testing value, optional
         #slow_down_in_millis = 30
-        #testing value, should really be removed and read from consensus instead, optional
-        #cuckoo_size = 12
-
 
     "#;
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -45,7 +45,7 @@ pub const DEFAULT_SIZESHIFT: u8 = 30;
 /// Lower Cuckoo size shift for tests and testnet
 /// This should be changed to correspond with the
 /// loaded plugin if using cuckoo-miner
-pub const TEST_SIZESHIFT: u8 = 12;
+pub const TEST_SIZESHIFT: u8 = 16;
 
 /// Default Cuckoo Cycle easiness, high enough to have good likeliness to find
 /// a solution.

--- a/core/src/pow/cuckoo.rs
+++ b/core/src/pow/cuckoo.rs
@@ -18,6 +18,7 @@
 //! miner will be much faster in almost every environment.
 
 use std::collections::HashSet;
+use std::collections::HashMap;
 use std::cmp;
 
 use crypto::digest::Digest;
@@ -162,7 +163,8 @@ pub struct Miner {
 impl MiningWorker for Miner {
 
 	/// Creates a new miner
-	fn new(ease: u32, sizeshift: u32) -> Miner {
+	fn new(ease: u32, 
+		   sizeshift: u32) -> Miner {
 		let size = 1 << sizeshift;
 		let graph = vec![0; size + 1];
 		let easiness = (ease as u64) * (size as u64) / 100;

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -113,7 +113,8 @@ mod test {
 	fn genesis_pow() {
 		let mut b = genesis::genesis();
 		b.header.nonce = 310;
-		pow_size(&mut b.header, Difficulty::from_num(MINIMUM_DIFFICULTY), 12).unwrap();
+		let mut internal_miner = cuckoo::Miner::new(EASINESS, 12);
+		pow_size(&mut internal_miner, &mut b.header, Difficulty::from_num(MINIMUM_DIFFICULTY), 12).unwrap();
 		assert!(b.header.nonce != 310);
 		assert!(b.header.pow.to_difficulty() >= Difficulty::from_num(MINIMUM_DIFFICULTY));
 		assert!(verify_size(&b.header, 12));

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -24,6 +24,7 @@
 
 mod siphash;
 pub mod cuckoo;
+use std::collections::HashMap;
 
 use time;
 
@@ -42,7 +43,8 @@ use pow::cuckoo::{Cuckoo, Miner, Error};
 pub trait MiningWorker {
 	
 	//This only sets parameters and does initialisation work now
-	fn new(ease: u32, sizeshift: u32) -> Self;
+	fn new(ease: u32, 
+		   sizeshift: u32) -> Self;
 	
 	//Actually perform a mining attempt on the given input and
 	//return a proof if found

--- a/grin.toml
+++ b/grin.toml
@@ -57,7 +57,7 @@ enable_mining = true
 
 #Whether to use cuckoo-miner,  and related parameters
 
-use_cuckoo_miner = false
+use_cuckoo_miner = true
 
 #If using cuckoo_miner, the directory in which plugins are installed
 #if not specified, grin will look in the directory /deps relative

--- a/grin.toml
+++ b/grin.toml
@@ -13,48 +13,81 @@
 [server]
 
 #the address on which services will listen, e.g. Transaction Pool
+
 api_http_addr = "127.0.0.1:13413"
 
 #the directory, relative to current, in which the grin blockchain
 #is stored
+
 db_root = ".grin"
 
 #How to seed this server, can be None, List or WebStatic
+
 seeding_type = "None"
 
 #if seeding_type = List, the list of peers to connect to.
 #seeds = ["192.168.0.1:8080","192.168.0.2:8080"]
 
-#Whether to run in test mode, which at the moment affects cuckoo_size
-#if this is false tries to use a slow cuckoo30 at the moment, not 
-#recommended
+#Whether to run in test mode. This affects the size of
+#cuckoo graph. 
+#If this is true,  CONSENSUS::TEST_SIZESHIFT is used
+#If this is false, CONSENSUS::DEFAULT_SIZESHIFT is used
+
 test_mode = true
 
 #7 = Bit flags for FULL_NODE, this structure needs to be changed
 #internally to make it more configurable
+
 capabilities = [7]
         
 #The P2P server details (i.e. the server that communicates with other
 #grin server nodes
+
 [server.p2p_config]
 host = "127.0.0.1"
 port = 13414
         
 #Mining details. This section is optional. If it's not here, the server 
 #will default to not mining. 
-
 [mining]
+
 #flag whether mining is enabled
+
 enable_mining = true
 
+#Whether to use cuckoo-miner,  and related parameters
+
+use_cuckoo_miner = false
+
+#If using cuckoo_miner, the directory in which plugins are installed
+#if not specified, grin will look in the directory /deps relative
+#to the executable
+
+#cuckoo_miner_plugin_dir = "target/debug/deps"
+
+#if using cuckoo_miner, the implementation to use.. currently
+#just filters for this word in the filenames in the plugin 
+#directory
+#Plugins currently included are:
+#"simple" : the basic cuckoo algorithm
+#"edgetrim" : an algorithm trading speed for a much lower memory footpring
+#Not included but verified working:
+#"cuda" a gpu miner - which currently needs to bebuilt and installed 
+#separately from#the cuckoo-miner repository. Instructions found there
+
+cuckoo_miner_plugin_type = "simple"
+
+#the list of parameters if you're using "edgetrim"
+#cuckoo_miner_parameter_list = {NUM_THREADS=4, NUM_TRIMS=7}
+
 #the wallet reciever to which coinbase rewards will be sent
+
 wallet_receiver_url = "http://127.0.0.1:13415"
 
 #whether to ignore the reward (mostly for testing)
+
 burn_reward = true
 
 #testing value, optional
 #slow_down_in_millis = 30
 
-#testing value, should really be removed and read from consensus instead, optional
-#cuckoo_size = 12

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -4,10 +4,6 @@ version = "0.1.0"
 authors = ["Ignotus Peverell <igno.peverell@protonmail.com>"]
 workspace = ".."
 
-[features]
-# Compliation flag whether to include the experimental cuckoo-miner crate
-use-cuckoo-miner = []
-
 [dependencies]
 grin_api = { path = "../api" }
 grin_chain = { path = "../chain" }
@@ -19,7 +15,7 @@ grin_util = { path = "../util" }
 grin_wallet = { path = "../wallet" }
 secp256k1zkp = { path = "../secp256k1zkp" }
 
-#cuckoo_miner = { version = "*", optional=true, path = "../../cuckoo-miner"}
+cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration"}
 
 env_logger="^0.3.5"
 futures = "^0.1.9"

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -46,12 +46,10 @@ extern crate grin_util as util;
 extern crate grin_wallet as wallet;
 extern crate secp256k1zkp as secp;
 
-#[cfg(feature = "use-cuckoo-miner")]
 extern crate cuckoo_miner;
 
 mod adapters;
 mod miner;
-#[cfg(feature = "use-cuckoo-miner")]
 mod plugin;
 mod server;
 mod seed;

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -56,6 +56,6 @@ mod seed;
 mod sync;
 mod types;
 
-
 pub use server::{Server};
 pub use types::{ServerConfig, MinerConfig, Seeding, ServerStats};
+pub use plugin::PluginMiner;

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -78,7 +78,7 @@ impl Miner {
 
 	/// Starts the mining loop, building a new block on top of the existing
 	/// chain anytime required and looking for PoW solution.
-	pub fn run_loop<T: MiningWorker>(&self, mut miner:T) {
+	pub fn run_loop<T: MiningWorker>(&self, mut miner:T, cuckoo_size:u32) {
 
 		info!("(Server ID: {}) Starting miner loop.", self.debug_output_id);
 		let mut coinbase = self.get_coinbase();
@@ -95,7 +95,7 @@ impl Miner {
 			let mut sol = None;
 			debug!("(Server ID: {}) Mining at Cuckoo{} for at most 2 secs on block {} at difficulty {}.",
 			       self.debug_output_id,
-			       self.config.cuckoo_size.unwrap(),
+			       cuckoo_size,
 			       latest_hash,
 			       b.header.difficulty);
 			let mut iter_count = 0;
@@ -134,7 +134,7 @@ impl Miner {
 				info!("(Server ID: {}) Found valid proof of work, adding block {}.",
 					  self.debug_output_id, b.hash());
 					b.header.pow = proof;
-				let opts = if self.config.cuckoo_size.unwrap() < consensus::DEFAULT_SIZESHIFT as u32 {
+				let opts = if cuckoo_size < consensus::DEFAULT_SIZESHIFT as u32 {
 					chain::EASY_POW
 				} else {
 					chain::NONE

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::convert::From;
+use std::collections::HashMap;
 
 use api;
 use chain;
@@ -103,6 +104,19 @@ pub struct MinerConfig {
 	/// Whether to start the miner with the server
 	pub enable_mining: bool,
 
+	/// Whether to use the cuckoo-miner crate and plugin for mining
+	pub use_cuckoo_miner: bool,
+
+	/// The location in which cuckoo miner plugins are stored
+	pub cuckoo_miner_plugin_dir: Option<String>,
+
+	/// The type of plugin to use (ends up filtering the filename)
+	pub cuckoo_miner_plugin_type: Option<String>,
+
+	/// Cuckoo-miner parameters... these vary according
+	/// to the plugin being loaded
+	pub cuckoo_miner_parameter_list: Option<HashMap<String, u32>>,
+
 	/// Base address to the HTTP wallet receiver
 	pub wallet_receiver_url: String,
 
@@ -113,10 +127,6 @@ pub struct MinerConfig {
 	/// a testing attribute for the time being that artifically slows down the
 	/// mining loop by adding a sleep to the thread
 	pub slow_down_in_millis: Option<u64>,
-
-	/// Size of Cuckoo Cycle to mine on
-	pub cuckoo_size: Option<u32>,
-
 
 }
 
@@ -139,10 +149,13 @@ impl Default for MinerConfig {
 	fn default() -> MinerConfig {
 		MinerConfig {
 			enable_mining: false,
+			use_cuckoo_miner: false,
+			cuckoo_miner_plugin_dir: None,
+			cuckoo_miner_plugin_type: None,
+			cuckoo_miner_parameter_list: None,
 			wallet_receiver_url: "http://localhost:13416".to_string(),
 			burn_reward: false,
 			slow_down_in_millis: Some(0),
-			cuckoo_size: Some(0)
 		}
 	}
 }

--- a/grin/tests/framework.rs
+++ b/grin/tests/framework.rs
@@ -107,9 +107,6 @@ pub struct LocalServerContainerConfig {
     //Whether to burn mining rewards
     pub burn_mining_rewards: bool,
 
-    //size of cuckoo graph for mining
-    pub cuckoo_size: u32,
-
     //full address to send coinbase rewards to
     pub coinbase_wallet_address: String,
 
@@ -133,7 +130,6 @@ impl Default for LocalServerContainerConfig {
             is_seeding: false,
             start_miner: false,
             start_wallet: false,
-            cuckoo_size: consensus::TEST_SIZESHIFT as u32,
             burn_mining_rewards: false,
             coinbase_wallet_address: String::from(""),
             wallet_validating_node_url: String::from(""),
@@ -232,7 +228,6 @@ impl LocalServerContainer {
         let mut miner_config = grin::MinerConfig {
             enable_mining: self.config.start_miner,
             burn_reward: self.config.burn_mining_rewards,
-            cuckoo_size: Some(self.config.cuckoo_size),
             wallet_receiver_url : self.config.coinbase_wallet_address.clone(),
             slow_down_in_millis: Some(self.config.miner_slowdown_in_millis.clone()),
             ..Default::default()

--- a/grin/tests/framework.rs
+++ b/grin/tests/framework.rs
@@ -228,11 +228,14 @@ impl LocalServerContainer {
         let mut miner_config = grin::MinerConfig {
             enable_mining: self.config.start_miner,
             burn_reward: self.config.burn_mining_rewards,
+            use_cuckoo_miner: true,
+            cuckoo_miner_plugin_dir: Some(String::from("../target/debug/deps")),
+            cuckoo_miner_plugin_type: Some(String::from("simple")),
             wallet_receiver_url : self.config.coinbase_wallet_address.clone(),
             slow_down_in_millis: Some(self.config.miner_slowdown_in_millis.clone()),
             ..Default::default()
         };
-
+          
         if self.config.start_miner == true {
             println!("starting Miner on port {}", self.config.p2p_server_port);
             s.start_miner(miner_config);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -196,6 +196,9 @@ fn simulate_block_propagation() {
   let miner_config = grin::MinerConfig{
     enable_mining: true,
     burn_reward: true,
+    use_cuckoo_miner: true,
+    cuckoo_miner_plugin_dir: Some(String::from("../target/debug/deps")),
+    cuckoo_miner_plugin_type: Some(String::from("simple")),
     ..Default::default()
   };
 
@@ -251,7 +254,10 @@ fn simulate_full_sync() {
 
   let miner_config = grin::MinerConfig{
     enable_mining: true,
-    burn_reward: true,    
+    burn_reward: true,
+    use_cuckoo_miner: true,
+    cuckoo_miner_plugin_dir: Some(String::from("../target/debug/deps")),
+    cuckoo_miner_plugin_type: Some(String::from("simple")),
     ..Default::default()
   };
 
@@ -269,7 +275,7 @@ fn simulate_full_sync() {
 
   // mine a few blocks on server 1
   servers[0].start_miner(miner_config);
-  thread::sleep(time::Duration::from_secs(15));
+  thread::sleep(time::Duration::from_secs(45));
 
   // connect 1 and 2
   let addr = format!("{}:{}", "127.0.0.1", 11001);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -153,9 +153,6 @@ fn simulate_parallel_mining(){
     server_config.start_wallet = true;
     server_config.is_seeding = true;
 
-    //This is the default value, can play with this here for convenience
-    server_config.cuckoo_size=consensus::TEST_SIZESHIFT as u32;
-
     pool.create_server(&mut server_config);
 
     //point next servers at first seed
@@ -199,7 +196,6 @@ fn simulate_block_propagation() {
   let miner_config = grin::MinerConfig{
     enable_mining: true,
     burn_reward: true,
-    cuckoo_size: Some(consensus::TEST_SIZESHIFT as u32),
     ..Default::default()
   };
 
@@ -255,8 +251,7 @@ fn simulate_full_sync() {
 
   let miner_config = grin::MinerConfig{
     enable_mining: true,
-    burn_reward: true,
-    cuckoo_size: Some(consensus::TEST_SIZESHIFT as u32),
+    burn_reward: true,    
     ..Default::default()
   };
 


### PR DESCRIPTION
With these changes, cuckoo-miner (a particular tag made just for testing) is fully integrated into grin, and all of the variants and options can be controlled via the grin.toml config file. Cuckoo-miner is turned off by default, but if you change the use_cuckoo_miner to true in the config file, it'll pick up and use the simple memory-hog miner. The edge trimming variant miner and its options are also included. Cuda miner should work if you build it from the cuckoo-miner repository and configure properly, but it's not included here as it would break many environments.

Couple of points:
-Removed conditional dependencies for including cuckoo miner. It's now being pulled from a specific tag in the cuckoo_miner repository.
-Removed the cuckoo_size field from the mining config, because it was confusing and conflicting with the consensus values. The cuckoo size is always driven by either TEST_SIZESHIFT or DEFAULT_SIZESHIFT now, with test mode turned on and off via the config file
-Changed the TEST_SIZESHIFT default value to 16, as that's John Tromp's recommended minimum for the edge trimming miner.

All miner parameters are documented in the config file, and if anything's misconfigured there should be a helpful log::error! message indicating what the problem is. Also tested cuckoo-miner integration on both linux and mac, all seems working as intended for now.


