### PR TITLE
Updates to ensure multithreaded CI tests don't fail

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -70,7 +70,8 @@ use_cuckoo_miner = true
 #directory
 #Plugins currently included are:
 #"simple" : the basic cuckoo algorithm
-#"edgetrim" : an algorithm trading speed for a much lower memory footpring
+#"edgetrim" : an algorithm trading speed for a much lower memory footprint
+#"tomato" : Time memory-tradeoff... low memory but very slow
 #Not included but verified working:
 #"cuda" a gpu miner - which currently needs to bebuilt and installed 
 #separately from#the cuckoo-miner repository. Instructions found there

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -15,7 +15,7 @@ grin_util = { path = "../util" }
 grin_wallet = { path = "../wallet" }
 secp256k1zkp = { path = "../secp256k1zkp" }
 
-cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration"}
+cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration_2"}
 
 env_logger="^0.3.5"
 futures = "^0.1.9"
@@ -29,3 +29,4 @@ tokio-core="^0.1.1"
 tokio-timer="^0.1.0"
 rand = "^0.3"
 tiny-keccak = "1.1"
+lazy_static = "0.2.8"

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -34,6 +34,8 @@ extern crate serde_derive;
 extern crate time;
 extern crate tokio_core;
 extern crate tokio_timer;
+#[macro_use]
+extern crate lazy_static;
 
 extern crate grin_api as api;
 extern crate grin_chain as chain;


### PR DESCRIPTION
This should fix the CI tests. I've tracked down the previous issue, and it's nothing nefarious with segfaulting libraries or the like, grin just needs to be mindful of not loading/unloading the mining plugin while another thread is trying to use it to mine. The query functionality I have in cuckoo-miner, which loads all the plugins in a directory and gets a list of each one's parameters, unloads the current plugin to read each one, so a caller just needs to be careful of having one thread mine while another attempts to query the plugin directory. I've just made sure that the plugin directory is only queried once per invocation (before any mining starts), regardless of how many server threads are launched.