### PR TITLE
cleanup build warnings

### DIFF
--- a/api/src/endpoints.rs
+++ b/api/src/endpoints.rs
@@ -50,7 +50,7 @@ impl ApiEndpoint for ChainApi {
 		vec![Operation::Get]
 	}
 
-	fn get(&self, id: String) -> ApiResult<Tip> {
+	fn get(&self, _: String) -> ApiResult<Tip> {
 		self.chain.head().map_err(|e| Error::Internal(format!("{:?}", e)))
 	}
 }
@@ -74,7 +74,7 @@ impl ApiEndpoint for OutputApi {
 
 	fn get(&self, id: String) -> ApiResult<Output> {
 		debug!("GET output {}", id);
-		let c = util::from_hex(id.clone()).map_err(|e| Error::Argument(format!("Not a valid commitment: {}", id)))?;
+		let c = util::from_hex(id.clone()).map_err(|_| Error::Argument(format!("Not a valid commitment: {}", id)))?;
 
     match self.chain.get_unspent(&Commitment::from_vec(c)) {
       Some(utxo) => Ok(utxo),
@@ -110,7 +110,7 @@ impl<T> ApiEndpoint for PoolApi<T>
 		vec![Operation::Get, Operation::Custom("push".to_string())]
 	}
 
-	fn get(&self, id: String) -> ApiResult<PoolInfo> {
+	fn get(&self, _: String) -> ApiResult<PoolInfo> {
 		let pool = self.tx_pool.read().unwrap();
 		Ok(PoolInfo {
 			pool_size: pool.pool_size(),
@@ -119,9 +119,9 @@ impl<T> ApiEndpoint for PoolApi<T>
 		})
 	}
 
-	fn operation(&self, op: String, input: TxWrapper) -> ApiResult<()> {
+	fn operation(&self, _: String, input: TxWrapper) -> ApiResult<()> {
 		let tx_bin = util::from_hex(input.tx_hex)
-      .map_err(|e| Error::Argument(format!("Invalid hex in transaction wrapper.")))?;
+      .map_err(|_| Error::Argument(format!("Invalid hex in transaction wrapper.")))?;
 
 		let tx: Transaction = ser::deserialize(&mut &tx_bin[..]).map_err(|_| {
 				Error::Argument("Could not deserialize transaction, invalid format.".to_string())

--- a/api/src/endpoints.rs
+++ b/api/src/endpoints.rs
@@ -21,11 +21,10 @@
 //   }
 // }
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::thread;
 
 use core::core::{Transaction, Output};
-use core::core::hash::Hash;
 use core::ser;
 use chain::{self, Tip};
 use pool;
@@ -81,7 +80,7 @@ impl ApiEndpoint for OutputApi {
       Some(utxo) => Ok(utxo),
       None => Err(Error::NotFound),
     }
-		
+
 	}
 }
 

--- a/api/src/endpoints.rs
+++ b/api/src/endpoints.rs
@@ -92,7 +92,7 @@ pub struct PoolApi<T> {
 }
 
 #[derive(Serialize, Deserialize)]
-struct PoolInfo {
+pub struct PoolInfo {
 	pool_size: usize,
 	orphans_size: usize,
 	total_size: usize,
@@ -145,7 +145,7 @@ impl<T> ApiEndpoint for PoolApi<T>
 
 /// Dummy wrapper for the hex-encoded serialized transaction.
 #[derive(Serialize, Deserialize)]
-struct TxWrapper {
+pub struct TxWrapper {
 	tx_hex: String,
 }
 

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -30,9 +30,8 @@ use iron::{Iron, Request, Response, IronResult, IronError, status, headers, List
 use iron::method::Method;
 use iron::modifiers::Header;
 use iron::middleware::Handler;
-use iron::error::HttpResult;
 use router::Router;
-use serde::{Serialize, Deserialize};
+use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json;
 

--- a/api/src/rest.rs
+++ b/api/src/rest.rs
@@ -330,7 +330,6 @@ impl ApiServer {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use rest::*;
 
 	#[derive(Serialize, Deserialize)]
 	pub struct Animal {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -26,7 +26,6 @@ use core::pow;
 use types::*;
 use store;
 use core::global;
-use core::global::{MiningParameterMode,MINING_PARAMETER_MODE};
 
 /// Contextual information required to process a new block and either reject or
 /// accept it.
@@ -152,11 +151,10 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 			return Err(Error::DifficultyTooLow);
 		}
 
-		let param_ref=MINING_PARAMETER_MODE.read().unwrap();
 		let cycle_size = if ctx.opts.intersects(EASY_POW) {
 			global::sizeshift()
 		} else {
-			consensus::DEFAULT_SIZESHIFT 
+			consensus::DEFAULT_SIZESHIFT
 		};
 		debug!("Validating block with cuckoo size {}", cycle_size);
 		if !pow::verify_size(header, cycle_size as u32) {

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -14,7 +14,6 @@
 
 //! Implementation of the chain block acceptance (or refusal) pipeline.
 
-use std::convert::From;
 use std::sync::{Arc, Mutex};
 
 use secp;
@@ -22,10 +21,8 @@ use time;
 
 use core::consensus;
 use core::core::hash::{Hash, Hashed};
-use core::core::target::Difficulty;
-use core::core::{BlockHeader, Block, Proof};
+use core::core::{BlockHeader, Block};
 use core::pow;
-use core::ser;
 use types::*;
 use store;
 use core::global;
@@ -34,10 +31,15 @@ use core::global::{MiningParameterMode,MINING_PARAMETER_MODE};
 /// Contextual information required to process a new block and either reject or
 /// accept it.
 pub struct BlockContext {
+	/// The options
 	pub opts: Options,
+	/// The store
 	pub store: Arc<ChainStore>,
+	/// The adapter
 	pub adapter: Arc<ChainAdapter>,
+	/// The head
 	pub head: Tip,
+	/// The lock
 	pub lock: Arc<Mutex<bool>>,
 }
 
@@ -68,11 +70,12 @@ pub fn process_block(b: &Block, mut ctx: BlockContext) -> Result<Option<Tip>, Er
 		b.hash()
 	);
 
-	ctx.lock.lock();
+	let _ = ctx.lock.lock().unwrap();
 	add_block(b, &mut ctx)?;
 	update_head(b, &mut ctx)
 }
 
+/// Process the block header
 pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<Option<Tip>, Error> {
 
 	info!(
@@ -84,7 +87,7 @@ pub fn process_block_header(bh: &BlockHeader, mut ctx: BlockContext) -> Result<O
 	validate_header(&bh, &mut ctx)?;
 	add_block_header(bh, &mut ctx)?;
 
-	ctx.lock.lock();
+	let _ = ctx.lock.lock().unwrap();
 	update_header_head(bh, &mut ctx)
 }
 

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -41,6 +41,7 @@ pub struct ChainKVStore {
 }
 
 impl ChainKVStore {
+	/// Create new chain store
 	pub fn new(root_path: String) -> Result<ChainKVStore, Error> {
 		let db = grin_store::Store::open(format!("{}/{}", root_path, STORE_SUBPATH).as_str())?;
 		Ok(ChainKVStore { db: db })
@@ -152,7 +153,7 @@ impl ChainStore for ChainKVStore {
 				self.db.put_ser(
 					&u64_to_key(HEADER_HEIGHT_PREFIX, real_prev.height),
 					&real_prev,
-				);
+				).unwrap();
 				prev_h = real_prev.previous;
 				prev_height = real_prev.height - 1;
 			} else {

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -27,6 +27,7 @@ use grin_store;
 bitflags! {
   /// Options for block validation
   pub flags Options: u32 {
+    /// None flag
     const NONE = 0b00000001,
     /// Runs without checking the Proof of Work, mostly to make testing easier.
     const SKIP_POW = 0b00000010,
@@ -37,6 +38,7 @@ bitflags! {
   }
 }
 
+/// Errors
 #[derive(Debug)]
 pub enum Error {
 	/// The block doesn't fit anywhere in our chain
@@ -202,5 +204,5 @@ pub trait ChainAdapter {
 /// Dummy adapter used as a placeholder for real implementations
 pub struct NoopAdapter {}
 impl ChainAdapter for NoopAdapter {
-	fn block_accepted(&self, b: &Block) {}
+	fn block_accepted(&self, _: &Block) {}
 }

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -26,7 +26,6 @@ use std::thread;
 use rand::os::OsRng;
 
 use grin_chain::types::*;
-use grin_chain::store;
 use grin_core::core::hash::Hashed;
 use grin_core::core::target::Difficulty;
 use grin_core::pow;
@@ -42,7 +41,7 @@ use grin_core::pow::MiningWorker;
 
 #[test]
 fn mine_empty_chain() {
-	env_logger::init();
+	let _ = env_logger::init();
     global::set_mining_mode(MiningParameterMode::AutomatedTesting);
 	let mut rng = OsRng::new().unwrap();
 	let chain = grin_chain::Chain::init(".grin".to_string(), Arc::new(NoopAdapter {}))
@@ -60,7 +59,7 @@ fn mine_empty_chain() {
 	};
 	miner_config.cuckoo_miner_plugin_dir = Some(String::from("../target/debug/deps"));
 
-	let mut cuckoo_miner = cuckoo::Miner::new(consensus::EASINESS, global::sizeshift() as u32, global::proofsize()); 
+	let mut cuckoo_miner = cuckoo::Miner::new(consensus::EASINESS, global::sizeshift() as u32, global::proofsize());
 	for n in 1..4 {
 		let prev = chain.head_header().unwrap();
 		let mut b = core::Block::new(&prev, vec![], reward_key).unwrap();
@@ -88,7 +87,7 @@ fn mine_empty_chain() {
 
 #[test]
 fn mine_forks() {
-	env_logger::init();
+	let _ = env_logger::init();
 	let mut rng = OsRng::new().unwrap();
 	let chain = grin_chain::Chain::init(".grin2".to_string(), Arc::new(NoopAdapter {}))
 		.unwrap();

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -33,9 +33,7 @@ use grin_core::core;
 use grin_core::consensus;
 use grin_core::pow::cuckoo;
 use grin_core::global;
-use grin_core::global::{MiningParameterMode,MINING_PARAMETER_MODE};
-
-use grin::{ServerConfig, MinerConfig};
+use grin_core::global::MiningParameterMode;
 
 use grin_core::pow::MiningWorker;
 
@@ -51,7 +49,6 @@ fn mine_empty_chain() {
 	let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 	let reward_key = secp::key::SecretKey::new(&secp, &mut rng);
 
-	let server_config = ServerConfig::default();
 	let mut miner_config = grin::MinerConfig {
 		enable_mining: true,
 		burn_reward: true,

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -22,7 +22,6 @@ use std::fs::File;
 use toml;
 use grin::{ServerConfig,
            MinerConfig};
-use wallet::WalletConfig;
 
 use types::{ConfigMembers,
             GlobalConfig,
@@ -87,10 +86,10 @@ impl GlobalConfig {
                 return Ok(())
             }
         }
-        
+
         // Give up
         Err(ConfigError::FileNotFoundError(String::from("")))
-        
+
     }
 
     /// Takes the path to a config file, or if NONE, tries
@@ -102,7 +101,7 @@ impl GlobalConfig {
         if let Some(fp) = file_path {
             return_value.config_file_path = Some(PathBuf::from(&fp));
         } else {
-            return_value.derive_config_location();
+            return_value.derive_config_location().unwrap();
         }
 
         //No attempt at a config file, just return defaults
@@ -124,6 +123,7 @@ impl GlobalConfig {
         return_value.read_config()
     }
 
+    /// Read config
     pub fn read_config(mut self) -> Result<GlobalConfig, ConfigError> {
         let mut file = File::open(self.config_file_path.as_mut().unwrap())?;
         let mut contents = String::new();
@@ -149,6 +149,7 @@ impl GlobalConfig {
         }
     }
 
+    /// Serialize config
     pub fn ser_config(&mut self) -> Result<String, ConfigError> {
         let encoded:Result<String, toml::ser::Error> = toml::to_string(self.members.as_mut().unwrap());
         match encoded {
@@ -169,6 +170,7 @@ impl GlobalConfig {
         return self.members.as_mut().unwrap().wallet.as_mut().unwrap().enable_wallet;
     }*/
 
+    /// Enable mining
     pub fn mining_enabled(&mut self) -> bool {
         return self.members.as_mut().unwrap().mining.as_mut().unwrap().enable_mining;
     }
@@ -186,11 +188,11 @@ fn test_read_config() {
         test_mode = false
         #7 = FULL_NODE, not sure how to serialise this properly to use constants
         capabilities = [7]
-        
+
         [server.p2p_config]
         host = "127.0.0.1"
         port = 13414
-        
+
         #Mining section is optional, if it's not here it will default to not mining
         [mining]
         enable_mining = true

--- a/config/src/types.rs
+++ b/config/src/types.rs
@@ -20,7 +20,6 @@ use std::fmt;
 
 use grin::{ServerConfig,
            MinerConfig};
-use wallet::WalletConfig;
 
 
 /// Error type wrapping config errors.
@@ -54,7 +53,7 @@ impl fmt::Display for ConfigError {
             ConfigError::SerializationError(ref message) => {
                 write!(f, "Error serializing configuration: {}", message)
             }
-        }   
+        }
     }
 }
 
@@ -67,9 +66,9 @@ impl From<io::Error> for ConfigError {
     }
 }
 
-/// Going to hold all of the various configuration types 
+/// Going to hold all of the various configuration types
 /// separately for now, then put them together as a single
-/// ServerConfig object afterwards. This is to flatten 
+/// ServerConfig object afterwards. This is to flatten
 /// out the configuration file into logical sections,
 /// as they tend to be quite nested in the code
 /// Most structs optional, as they may or may not
@@ -77,12 +76,13 @@ impl From<io::Error> for ConfigError {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GlobalConfig {
-    //Keep track of the file we've read
+    ///Keep track of the file we've read
     pub config_file_path: Option<PathBuf>,
-    //keep track of whether we're using
-    //a config file or just the defaults
-    //for each member
+    /// keep track of whether we're using
+    /// a config file or just the defaults
+    /// for each member
     pub using_config_file: bool,
+    /// Global member config
     pub members: Option<ConfigMembers>,
 }
 
@@ -93,7 +93,9 @@ pub struct GlobalConfig {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConfigMembers {
+    /// Server config
     pub server: ServerConfig,
+    /// Mining config
     pub mining: Option<MinerConfig>,
     //removing wallet from here for now,
     //as its concerns are separate from the server's, really

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -24,7 +24,6 @@ use core::{Input, Output, Proof, TxKernel, Transaction, COINBASE_KERNEL, COINBAS
 use core::transaction::merkle_inputs_outputs;
 use consensus::REWARD;
 use consensus::MINIMUM_DIFFICULTY;
-use consensus::PROOFSIZE;
 use core::hash::{Hash, Hashed, ZERO_HASH};
 use core::target::Difficulty;
 use ser::{self, Readable, Reader, Writeable, Writer};

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -83,7 +83,10 @@ pub trait Committed {
 
 /// Proof of work
 pub struct Proof {
+    /// The nonces
 	pub nonces:Vec<u32>,
+    
+    /// The proof size
     pub proof_size: usize,
 }
 
@@ -124,7 +127,7 @@ impl Clone for Proof {
 }
 
 impl Proof {
-	
+
 	/// Builds a proof with all bytes zeroed out
 	pub fn new(in_nonces:Vec<u32>) -> Proof {
 		Proof {

--- a/core/src/core/sumtree.rs
+++ b/core/src/core/sumtree.rs
@@ -698,6 +698,7 @@ where
 }
 
 #[allow(dead_code)]
+#[allow(missing_docs)]
 pub fn print_tree<T>(tree: &SumTree<T>)
 where
 	T: Summable + Writeable,

--- a/core/src/core/target.rs
+++ b/core/src/core/target.rs
@@ -21,11 +21,9 @@
 
 use std::fmt;
 use std::ops::{Add, Mul, Div, Sub};
-use std::io::Cursor;
-use std::u64::MAX;
 
 use serde::{Serialize, Serializer, Deserialize, Deserializer, de};
-use byteorder::{ByteOrder, ReadBytesExt, BigEndian};
+use byteorder::{ByteOrder, BigEndian};
 
 use core::hash::Hash;
 use ser::{self, Reader, Writer, Writeable, Readable};
@@ -150,7 +148,7 @@ impl<'de> de::Visitor<'de> for DiffVisitor {
 		where E: de::Error
 	{
 		let num_in = s.parse::<u64>();
-		if let Err(e)=num_in {
+		if let Err(_)=num_in {
         	return Err(de::Error::invalid_value(de::Unexpected::Str(s), &"a value number"));
       	};
 		Ok(Difficulty { num: num_in.unwrap() })

--- a/core/src/genesis.rs
+++ b/core/src/genesis.rs
@@ -18,7 +18,6 @@ use time;
 
 use core;
 use consensus::MINIMUM_DIFFICULTY;
-use consensus::PROOFSIZE;
 use core::hash::Hashed;
 use core::target::Difficulty;
 use global;

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -28,14 +28,19 @@ use consensus::DEFAULT_SIZESHIFT;
 /// Define these here, as they should be developer-set, not really tweakable
 /// by users
 
+/// Automated testing sizeshift
 pub const AUTOMATED_TESTING_SIZESHIFT:u8 = 10;
 
+/// Automated testing proof size
 pub const AUTOMATED_TESTING_PROOF_SIZE:usize = 4;
 
+/// User testing sizeshift
 pub const USER_TESTING_SIZESHIFT:u8 = 16;
 
+/// User testing proof size
 pub const USER_TESTING_PROOF_SIZE:usize = 42;
 
+/// Mining parameter modes
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MiningParameterMode {
 	/// For CI testing
@@ -49,14 +54,17 @@ pub enum MiningParameterMode {
 }
 
 lazy_static!{
+    /// The mining parameter mode
     pub static ref MINING_PARAMETER_MODE: RwLock<MiningParameterMode> = RwLock::new(MiningParameterMode::Production);
 }
 
+/// Set the mining mode
 pub fn set_mining_mode(mode:MiningParameterMode){
 	let mut param_ref=MINING_PARAMETER_MODE.write().unwrap();
 	*param_ref=mode;
 }
 
+/// The sizeshift
 pub fn sizeshift() -> u8 {
 	let param_ref=MINING_PARAMETER_MODE.read().unwrap();
 	match *param_ref {
@@ -66,6 +74,7 @@ pub fn sizeshift() -> u8 {
 	}
 }
 
+/// The proofsize
 pub fn proofsize() -> usize {
 	let param_ref=MINING_PARAMETER_MODE.read().unwrap();
 	match *param_ref {
@@ -75,6 +84,7 @@ pub fn proofsize() -> usize {
 	}
 }
 
+/// Are we in automated testing mode?
 pub fn is_automated_testing_mode() -> bool {
 	let param_ref=MINING_PARAMETER_MODE.read().unwrap();
 	if let MiningParameterMode::AutomatedTesting=*param_ref {
@@ -83,4 +93,3 @@ pub fn is_automated_testing_mode() -> bool {
 		return false;
 	}
 }
-

--- a/core/src/macros.rs
+++ b/core/src/macros.rs
@@ -39,6 +39,7 @@ macro_rules! try_map_vec {
 
 /// Eliminates some of the verbosity in having iter and collect
 /// around every fitler_map call.
+#[macro_export]
 macro_rules! filter_map_vec {
   ($thing:expr, $mapfn:expr ) => {
     $thing.iter()
@@ -52,6 +53,7 @@ macro_rules! filter_map_vec {
 /// Example:
 ///   let foo = vec![1,2,3]
 ///   println!(tee!(foo, foo.append(vec![3,4,5]))
+#[macro_export]
 macro_rules! tee {
   ($thing:ident, $thing_expr:expr) => {
     {

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -41,10 +41,15 @@ use pow::cuckoo::{Cuckoo, Error};
 ///
 
 pub trait MiningWorker {
-	
+
 	/// This only sets parameters and does initialisation work now
+<<<<<<< HEAD
 	fn new(ease: u32, sizeshift: u32, proof_size:usize) -> Self;
 	
+=======
+	fn new(ease: u32, sizeshift: u32) -> Self;
+
+>>>>>>> grin_core build and test
 	/// Actually perform a mining attempt on the given input and
 	/// return a proof if found
 	fn mine(&mut self, header: &[u8]) -> Result<Proof, Error>;
@@ -70,8 +75,8 @@ pub fn pow20<T: MiningWorker>(miner:&mut T, bh: &mut BlockHeader, diff: Difficul
 
 /// Runs a proof of work computation over the provided block using the provided Mining Worker,
 /// until the required difficulty target is reached. May take a while for a low target...
-pub fn pow_size<T: MiningWorker>(miner:&mut T, bh: &mut BlockHeader, 
-								 diff: Difficulty, sizeshift: u32) -> Result<(), Error> {
+pub fn pow_size<T: MiningWorker>(miner:&mut T, bh: &mut BlockHeader,
+								 diff: Difficulty, _: u32) -> Result<(), Error> {
 	let start_nonce = bh.nonce;
 
 	// try to find a cuckoo cycle on that header hash

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -31,8 +31,6 @@ use consensus::EASINESS;
 use core::BlockHeader;
 use core::hash::Hashed;
 use core::Proof;
-use global;
-use global::{MiningParameterMode, MINING_PARAMETER_MODE};
 use core::target::Difficulty;
 use pow::cuckoo::{Cuckoo, Error};
 
@@ -104,9 +102,12 @@ pub fn pow_size<T: MiningWorker>(miner:&mut T, bh: &mut BlockHeader,
 #[cfg(test)]
 mod test {
 	use super::*;
+	use global;
 	use core::target::Difficulty;
 	use genesis;
   	use consensus::MINIMUM_DIFFICULTY;
+	use global::MiningParameterMode;
+
 
 	#[test]
 	fn genesis_pow() {

--- a/core/src/pow/mod.rs
+++ b/core/src/pow/mod.rs
@@ -43,13 +43,8 @@ use pow::cuckoo::{Cuckoo, Error};
 pub trait MiningWorker {
 
 	/// This only sets parameters and does initialisation work now
-<<<<<<< HEAD
 	fn new(ease: u32, sizeshift: u32, proof_size:usize) -> Self;
-	
-=======
-	fn new(ease: u32, sizeshift: u32) -> Self;
 
->>>>>>> grin_core build and test
 	/// Actually perform a mining attempt on the given input and
 	/// return a proof if found
 	fn mine(&mut self, header: &[u8]) -> Result<Proof, Error>;

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -388,6 +388,7 @@ impl Writeable for [u8; 4] {
 
 /// Useful marker trait on types that can be sized byte slices
 pub trait AsFixedBytes: Sized + AsRef<[u8]> {
+	/// The length in bytes
 	fn len(&self) -> usize;
 }
 

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
-use std::ops::Deref;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::thread;
 
 use chain::{self, ChainAdapter};
 use core::core::{self, Output};
 use core::core::hash::{Hash, Hashed};
 use core::core::target::Difficulty;
-use p2p::{self, NetAdapter, Server, PeerStore, PeerData, Capabilities, State};
+use p2p::{self, NetAdapter, Server, PeerStore, PeerData, State};
 use pool;
 use secp::pedersen::Commitment;
 use util::OneTime;
@@ -211,8 +210,8 @@ impl NetToChainAdapter {
 		let arc_sync = Arc::new(sync);
 		self.syncer.init(arc_sync.clone());
 		thread::Builder::new().name("syncer".to_string()).spawn(move || {
-			arc_sync.run();
-		});
+			arc_sync.run().unwrap();
+		}).unwrap();
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -209,9 +209,17 @@ impl NetToChainAdapter {
 	pub fn start_sync(&self, sync: sync::Syncer) {
 		let arc_sync = Arc::new(sync);
 		self.syncer.init(arc_sync.clone());
-		thread::Builder::new().name("syncer".to_string()).spawn(move || {
-			arc_sync.run().unwrap();
-		}).unwrap();
+		let spawn_result = thread::Builder::new().name("syncer".to_string()).spawn(move || {
+			let sync_run_result = arc_sync.run();
+			match sync_run_result {
+				Ok(_) => {}
+				Err(_) => {}
+			}
+		});
+		match spawn_result {
+			Ok(_) => {}
+			Err(_) => {}
+		}
 	}
 
 	/// Prepare options for the chain pipeline

--- a/grin/src/adapters.rs
+++ b/grin/src/adapters.rs
@@ -26,7 +26,6 @@ use secp::pedersen::Commitment;
 use util::OneTime;
 use store;
 use sync;
-use core::global;
 use core::global::{MiningParameterMode,MINING_PARAMETER_MODE};
 
 /// Implementation of the NetAdapter for the blockchain. Gets notified when new

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -65,7 +65,7 @@ pub struct HeaderPartWriter {
 
 impl Default for HeaderPartWriter {
 	fn default() -> HeaderPartWriter {
-		HeaderPartWriter { 
+		HeaderPartWriter {
 			bytes_written: 0,
 			writing_pre: true,
 			pre_nonce: Vec::new(),
@@ -91,13 +91,13 @@ impl ser::Writer for HeaderPartWriter {
 	fn write_fixed_bytes<T: AsFixedBytes>(&mut self, bytes_in: &T) -> Result<(), ser::Error> {
 		if self.writing_pre {
 			for i in 0..bytes_in.len() {self.pre_nonce.push(bytes_in.as_ref()[i])};
-			
+
 		} else if self.bytes_written!=0 {
 			for i in 0..bytes_in.len() {self.post_nonce.push(bytes_in.as_ref()[i])};
 		}
 
 		self.bytes_written+=bytes_in.len();
-		
+
 		if self.bytes_written==PRE_NONCE_SIZE && self.writing_pre {
 			self.writing_pre=false;
 			self.bytes_written=0;
@@ -140,20 +140,20 @@ impl Miner {
 	}
 
 	/// Inner part of the mining loop for cuckoo-miner asynch mode
-	pub fn inner_loop_async(&self, plugin_miner:&mut PluginMiner, 
-							difficulty:Difficulty, 
+	pub fn inner_loop_async(&self, plugin_miner:&mut PluginMiner,
+							difficulty:Difficulty,
 							b:&mut Block,
 							cuckoo_size: u32,
 							head:&BlockHeader,
-							latest_hash:&Hash) 
+							latest_hash:&Hash)
 		-> Option<Proof> {
-		
+
 		debug!("(Server ID: {}) Mining at Cuckoo{} for at most 2 secs at height {} and difficulty {}.",
 			self.debug_output_id,
 			cuckoo_size,
 			b.header.height,
 			b.header.difficulty);
-		
+
 		// look for a pow for at most 2 sec on the same block (to give a chance to new
 		// transactions) and as long as the head hasn't changed
 		// Will change this to something else at some point
@@ -189,12 +189,12 @@ impl Miner {
 	}
 
 	/// The inner part of mining loop for synchronous mode
-	pub fn inner_loop_sync<T: MiningWorker>(&self, 
-						    miner:&mut T, 
+	pub fn inner_loop_sync<T: MiningWorker>(&self,
+						    miner:&mut T,
 							b:&mut Block,
-							cuckoo_size: u32, 
+							cuckoo_size: u32,
 							head:&BlockHeader,
-							latest_hash:&mut Hash) 
+							latest_hash:&mut Hash)
 		-> Option<Proof> {
 		// look for a pow for at most 2 sec on the same block (to give a chance to new
 		// transactions) and as long as the head hasn't changed
@@ -206,7 +206,7 @@ impl Miner {
 		       latest_hash,
 		       b.header.difficulty);
 		let mut iter_count = 0;
-		
+
 		if self.config.slow_down_in_millis != None && self.config.slow_down_in_millis.unwrap() > 0 {
 			debug!("(Server ID: {}) Artificially slowing down loop by {}ms per iteration.",
 			self.debug_output_id,
@@ -215,7 +215,7 @@ impl Miner {
 
 		let mut sol=None;
 		while head.hash() == *latest_hash && time::get_time().sec < deadline {
-							
+
 			let pow_hash = b.hash();
 			if let Ok(proof) = miner.mine(&pow_hash[..]) {
 				let proof_diff=proof.clone().to_difficulty();
@@ -250,9 +250,9 @@ impl Miner {
 
 	/// Starts the mining loop, building a new block on top of the existing
 	/// chain anytime required and looking for PoW solution.
-	pub fn run_loop(&self, 
-					miner_config:MinerConfig, 
-					server_config:ServerConfig, 
+	pub fn run_loop(&self,
+					miner_config:MinerConfig,
+					server_config:ServerConfig,
 					cuckoo_size:u32,
 					proof_size:usize) {
 
@@ -283,28 +283,28 @@ impl Miner {
 			}
 			if let Some(mut p) = plugin_miner.as_mut() {
 				if use_async {
-					sol = self.inner_loop_async(&mut p, 
-						b.header.difficulty.clone(), 
+					sol = self.inner_loop_async(&mut p,
+						b.header.difficulty.clone(),
 						&mut b,
 						cuckoo_size,
 						&head,
 						&latest_hash);
 				} else {
-					sol = self.inner_loop_sync(p, 
+					sol = self.inner_loop_sync(p,
 					&mut b,
 					cuckoo_size,
 					&head,
 					&mut latest_hash);
 				}
-			} 
+			}
 			if let Some(mut m) = miner.as_mut() {
-				sol = self.inner_loop_sync(m, 
+				sol = self.inner_loop_sync(m,
 					&mut b,
 					cuckoo_size,
 					&head,
 					&mut latest_hash);
 			}
-			
+
 			// if we found a solution, push our block out
 			if let Some(proof) = sol {
 				info!("(Server ID: {}) Found valid proof of work, adding block {}.",
@@ -322,7 +322,7 @@ impl Miner {
 				} else {
 					coinbase = self.get_coinbase();
 				}
-			} 
+			}
 		}
 	}
 

--- a/grin/src/plugin.rs
+++ b/grin/src/plugin.rs
@@ -23,7 +23,7 @@ use core::pow::cuckoo;
 use core::pow::cuckoo::Error;
 use core::pow::MiningWorker;
 use core::consensus::DEFAULT_SIZESHIFT;
-use core::global; 
+use core::global;
 use std::collections::HashMap;
 
 use core::core::Proof;
@@ -35,9 +35,7 @@ use cuckoo_miner::{
 	CuckooMiner,
 	CuckooPluginManager,
 	CuckooMinerConfig,
-	CuckooMinerError,
-	CuckooMinerSolution,
-	CuckooPluginCapabilities};
+	CuckooMinerSolution};
 
 //For now, we're just going to keep a static reference around to the loaded config
 //And not allow querying the plugin directory twice once a plugin has been selected
@@ -48,7 +46,9 @@ lazy_static!{
     static ref LOADED_CONFIG: Mutex<Option<CuckooMinerConfig>> = Mutex::new(None);
 }
 
+/// plugin miner
 pub struct PluginMiner {
+	/// the miner
 	pub miner:Option<CuckooMiner>,
 	last_solution: CuckooMinerSolution,
 	config: CuckooMinerConfig,
@@ -65,6 +65,7 @@ impl Default for PluginMiner {
 }
 
 impl PluginMiner {
+	/// Init the plugin miner
 	pub fn init(&mut self, miner_config: MinerConfig, server_config: ServerConfig){
 				//Get directory of executable
 		let mut exe_path=env::current_exe().unwrap();
@@ -83,8 +84,8 @@ impl PluginMiner {
 
 		//First, load and query the plugins in the given directory
 		//These should all be stored in 'deps' at the moment relative
-		//to the executable path, though they should appear somewhere else 
-		//when packaging is more//thought out 
+		//to the executable path, though they should appear somewhere else
+		//when packaging is more//thought out
 
 		let mut loaded_config_ref = LOADED_CONFIG.lock().unwrap();
 
@@ -100,7 +101,7 @@ impl PluginMiner {
     	let mut plugin_manager = CuckooPluginManager::new().unwrap();
     	let result=plugin_manager.load_plugin_dir(plugin_install_path);
 
-		if let Err(e) = result {
+		if let Err(_) = result {
 			error!("Unable to load cuckoo-miner plugin directory, either from configuration or [exe_path]/deps.");
 			panic!("Unable to load plugin directory... Please check configuration values");
 		}
@@ -115,7 +116,7 @@ impl PluginMiner {
 		//insert it into the miner configuration being created below
 
     	let mut config = CuckooMinerConfig::new();
-	
+
         info!("Mining using plugin: {}", caps[0].full_path.clone());
     	config.plugin_full_path = caps[0].full_path.clone();
 		if let Some(l) = miner_config.cuckoo_miner_parameter_list {
@@ -134,12 +135,13 @@ impl PluginMiner {
 			panic!("Unable to init mining plugin.");
 		}
 
-		self.config=config.clone();		
+		self.config=config.clone();
 		self.miner=Some(result.unwrap());
 	}
 
+	/// Get the miner
 	pub fn get_consumable(&mut self)->CuckooMiner{
-		
+
 		//this will load the associated plugin
 		let result=CuckooMiner::new(self.config.clone());
 		if let Err(e) = result {
@@ -148,7 +150,7 @@ impl PluginMiner {
 		}
 		result.unwrap()
 	}
-	
+
 }
 
 impl MiningWorker for PluginMiner {
@@ -158,7 +160,7 @@ impl MiningWorker for PluginMiner {
 	/// version of the miner for now, though this should become
 	/// configurable somehow
 
-	fn new(ease: u32, 
+	fn new(ease: u32,
 		   sizeshift: u32,
 		   proof_size: usize) -> Self {
 		PluginMiner::default()
@@ -175,4 +177,3 @@ impl MiningWorker for PluginMiner {
         Err(Error::NoSolution)
 	}
 }
-

--- a/grin/src/plugin.rs
+++ b/grin/src/plugin.rs
@@ -22,9 +22,7 @@ use std::env;
 use core::pow::cuckoo;
 use core::pow::cuckoo::Error;
 use core::pow::MiningWorker;
-use core::consensus::DEFAULT_SIZESHIFT;
 use core::global;
-use std::collections::HashMap;
 
 use core::core::Proof;
 use types::{MinerConfig, ServerConfig};
@@ -66,7 +64,7 @@ impl Default for PluginMiner {
 
 impl PluginMiner {
 	/// Init the plugin miner
-	pub fn init(&mut self, miner_config: MinerConfig, server_config: ServerConfig){
+	pub fn init(&mut self, miner_config: MinerConfig, _server_config: ServerConfig){
 				//Get directory of executable
 		let mut exe_path=env::current_exe().unwrap();
 		exe_path.pop();
@@ -160,9 +158,9 @@ impl MiningWorker for PluginMiner {
 	/// version of the miner for now, though this should become
 	/// configurable somehow
 
-	fn new(ease: u32,
-		   sizeshift: u32,
-		   proof_size: usize) -> Self {
+	fn new(_ease: u32,
+		   _sizeshift: u32,
+		   _proof_size: usize) -> Self {
 		PluginMiner::default()
 	}
 

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -19,10 +19,8 @@
 use rand::{thread_rng, Rng};
 use std::cmp::min;
 use std::net::SocketAddr;
-use std::ops::Deref;
 use std::str::{self, FromStr};
 use std::sync::Arc;
-use std::thread;
 use std::time;
 
 use cpupool;
@@ -93,7 +91,7 @@ impl Seeder {
 				for p in disconnected {
 					if p.is_banned() {
 						debug!("Marking peer {} as banned.", p.info.addr);
-						peer_store.update_state(p.info.addr, p2p::State::Banned);
+						peer_store.update_state(p.info.addr, p2p::State::Banned).unwrap();
 					}
 				}
 
@@ -240,11 +238,11 @@ fn connect_and_req(capab: p2p::Capabilities,
 		.then(move |p| {
 			match p {
 				Ok(Some(p)) => {
-					p.send_peer_request(capab);
+					p.send_peer_request(capab).unwrap();
 				}
 				Err(e) => {
 					error!("Peer request error: {:?}", e);
-					peer_store.update_state(addr, p2p::State::Defunct);
+					peer_store.update_state(addr, p2p::State::Defunct).unwrap();
 				}
 				_ => {}
 			}

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -91,7 +91,12 @@ impl Seeder {
 				for p in disconnected {
 					if p.is_banned() {
 						debug!("Marking peer {} as banned.", p.info.addr);
-						peer_store.update_state(p.info.addr, p2p::State::Banned).unwrap();
+						let update_result = peer_store.update_state(
+							p.info.addr, p2p::State::Banned);
+						match update_result {
+							Ok(()) => {}
+							Err(_) => {}
+						}
 					}
 				}
 
@@ -238,11 +243,19 @@ fn connect_and_req(capab: p2p::Capabilities,
 		.then(move |p| {
 			match p {
 				Ok(Some(p)) => {
-					p.send_peer_request(capab).unwrap();
+					let peer_result = p.send_peer_request(capab);
+					match peer_result {
+						Ok(()) => {}
+						Err(_) => {}
+					}
 				}
 				Err(e) => {
 					error!("Peer request error: {:?}", e);
-					peer_store.update_state(addr, p2p::State::Defunct).unwrap();
+					let update_result = peer_store.update_state(addr, p2p::State::Defunct);
+					match update_result {
+						Ok(()) => {}
+						Err(_) => {}
+					}
 				}
 				_ => {}
 			}

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -28,7 +28,6 @@ use tokio_timer::Timer;
 use adapters::*;
 use api;
 use chain;
-use core::consensus;
 use miner;
 use p2p;
 use pool;
@@ -36,7 +35,6 @@ use seed;
 use sync;
 use types::*;
 
-use plugin::PluginMiner;
 use core::global;
 
 /// Grin server holding internal structures.

--- a/grin/src/server.rs
+++ b/grin/src/server.rs
@@ -17,27 +17,22 @@
 //! as a facade.
 
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time;
 
-use futures::{future, Future, Stream};
+use futures::{Future, Stream};
 use tokio_core::reactor;
 use tokio_timer::Timer;
 
 use adapters::*;
 use api;
 use chain;
-use chain::ChainStore;
-use core::{self, consensus};
-use core::core::hash::Hashed;
-use core::pow::cuckoo;
-use core::pow::MiningWorker;
+use core::consensus;
 use miner;
 use p2p;
 use pool;
 use seed;
-use store;
 use sync;
 use types::*;
 
@@ -46,7 +41,9 @@ use core::global;
 
 /// Grin server holding internal structures.
 pub struct Server {
+	/// server config
 	pub config: ServerConfig,
+	/// event handle
 	evt_handle: reactor::Handle,
 	/// handle to our network server
 	p2p: Arc<p2p::Server>,
@@ -137,6 +134,7 @@ impl Server {
 		Ok(())
 	}
 
+	/// Number of peers
 	pub fn peer_count(&self) -> u32 {
 		self.p2p.peer_count()
 	}
@@ -152,10 +150,11 @@ impl Server {
 		miner.set_debug_output_id(format!("Port {}",self.config.p2p_config.unwrap().port));
 		let server_config = self.config.clone();
 		thread::spawn(move || {
-			miner.run_loop(config.clone(), server_config, cuckoo_size as u32, proof_size);		
+			miner.run_loop(config.clone(), server_config, cuckoo_size as u32, proof_size);
 		});
 	}
 
+	/// The chain head
 	pub fn head(&self) -> chain::Tip {
 		self.chain.head().unwrap()
 	}

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -20,7 +20,6 @@
 /// How many block bodies to download in parallel
 const MAX_BODY_DOWNLOADS: usize = 8;
 
-use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Instant, Duration};
@@ -152,7 +151,7 @@ impl Syncer {
 			while blocks_to_download.len() > 0 && blocks_downloading.len() < MAX_BODY_DOWNLOADS {
 				let h = blocks_to_download.pop().unwrap();
 				let peer = self.p2p.random_peer().unwrap();
-				peer.send_block_request(h);
+				peer.send_block_request(h).unwrap();
 				blocks_downloading.push((h, Instant::now()));
 			}
 			debug!("Requesting more full block hashes to download, total: {}.",
@@ -199,7 +198,7 @@ impl Syncer {
 		}
 		// ask for more headers if we got as many as required
 		if hs_len == (p2p::MAX_BLOCK_HEADERS as usize) {
-			self.request_headers();
+			self.request_headers().unwrap();
 		}
 	}
 

--- a/grin/src/sync.rs
+++ b/grin/src/sync.rs
@@ -151,7 +151,11 @@ impl Syncer {
 			while blocks_to_download.len() > 0 && blocks_downloading.len() < MAX_BODY_DOWNLOADS {
 				let h = blocks_to_download.pop().unwrap();
 				let peer = self.p2p.random_peer().unwrap();
-				peer.send_block_request(h).unwrap();
+				let send_result = peer.send_block_request(h);
+				match send_result {
+					Ok(_) => {}
+					Err(_) => {}
+				}
 				blocks_downloading.push((h, Instant::now()));
 			}
 			debug!("Requesting more full block hashes to download, total: {}.",

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -84,7 +84,7 @@ pub struct ServerConfig {
 
 	/// Method used to get the list of seed nodes for initial bootstrap.
 	pub seeding_type: Seeding,
-	
+
 	/// The list of seed nodes, if using Seeding as a seed type
 	pub seeds: Option<Vec<String>>,
 
@@ -173,6 +173,8 @@ impl Default for MinerConfig {
 
 #[derive(Clone)]
 pub struct ServerStats {
+	/// Number of peers
 	pub peer_count:u32,
+	/// Chain head
 	pub head: chain::Tip,
 }

--- a/grin/tests/framework.rs
+++ b/grin/tests/framework.rs
@@ -514,5 +514,4 @@ impl LocalServerContainerPool {
             }
         }
     }
-
 }

--- a/grin/tests/framework.rs
+++ b/grin/tests/framework.rs
@@ -30,23 +30,15 @@ extern crate futures_cpupool;
 use std::thread;
 use std::time;
 use std::default::Default;
-use std::mem;
 use std::fs;
-use std::sync::{Arc, Mutex, RwLock};
-use std::ops::Deref;
+use std::sync::{Arc, Mutex};
 
-use futures::{Future};
-use futures::future::join_all;
-use futures::task::park;
 use tokio_core::reactor;
-use tokio_core::reactor::Remote;
-use tokio_core::reactor::Handle;
 use tokio_timer::Timer;
 
 use secp::Secp256k1;
 
 use wallet::WalletConfig;
-use core::consensus;
 
 
 /// Just removes all results from previous runs
@@ -61,18 +53,19 @@ pub fn clean_all_output(test_name_dir:&str){
 
 /// Errors that can be returned by LocalServerContainer
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
 	Internal(String),
 	Argument(String),
-	NotFound,
+    NotFound,
 }
 
 /// All-in-one server configuration struct, for convenience
-/// 
+///
 
 #[derive(Clone)]
 pub struct LocalServerContainerConfig {
-    
+
     //user friendly name for the server, also denotes what dir
     //the data files will appear in
     pub name: String,
@@ -81,8 +74,8 @@ pub struct LocalServerContainerConfig {
     pub base_addr: String,
 
     //Port the server (p2p) is running on
-    pub p2p_server_port: u16, 
-    
+    pub p2p_server_port: u16,
+
     //Port the API server is running on
     pub api_server_port: u16,
 
@@ -113,7 +106,7 @@ pub struct LocalServerContainerConfig {
     pub coinbase_wallet_address: String,
 
     //When running a wallet, the address to check inputs and send
-    //finalised transactions to, 
+    //finalised transactions to,
     pub wallet_validating_node_url:String,
 
 
@@ -168,7 +161,7 @@ pub struct LocalServerContainer {
 
     //the list of peers to connect to
     pub peer_list: Vec<String>,
-    
+
     //base directory for the server instance
     working_dir: String,
 
@@ -193,8 +186,7 @@ impl LocalServerContainer {
        }))
     }
 
-    pub fn run_server(&mut self,
-                         duration_in_seconds: u64) -> grin::ServerStats
+    pub fn run_server(&mut self, duration_in_seconds: u64) -> grin::ServerStats
     {
         let mut event_loop = reactor::Core::new().unwrap();
 
@@ -208,7 +200,7 @@ impl LocalServerContainer {
             seeds=vec![self.config.seed_addr.to_string()];
         }
 
-        
+
         let s = grin::Server::future(
             grin::ServerConfig{
                 api_http_addr: api_addr,
@@ -227,7 +219,7 @@ impl LocalServerContainer {
             thread::sleep(time::Duration::from_millis(1000));
         }
 
-        let mut miner_config = grin::MinerConfig {
+        let miner_config = grin::MinerConfig {
             enable_mining: self.config.start_miner,
             burn_reward: self.config.burn_mining_rewards,
             use_cuckoo_miner: false,
@@ -238,7 +230,7 @@ impl LocalServerContainer {
             slow_down_in_millis: Some(self.config.miner_slowdown_in_millis.clone()),
             ..Default::default()
         };
-          
+
         if self.config.start_miner == true {
             println!("starting Miner on port {}", self.config.p2p_server_port);
             s.start_miner(miner_config);
@@ -251,7 +243,7 @@ impl LocalServerContainer {
 
         let timeout = Timer::default().sleep(time::Duration::from_secs(duration_in_seconds));
 
-        event_loop.run(timeout);
+        event_loop.run(timeout).unwrap();
 
         if self.wallet_is_running{
             self.stop_wallet();
@@ -260,15 +252,15 @@ impl LocalServerContainer {
         s.get_server_stats().unwrap()
 
     }
-        
+
     /// Starts a wallet daemon to receive and returns the
     /// listening server url
-    
-    pub fn run_wallet(&mut self, duration_in_seconds: u64) {
+
+    pub fn run_wallet(&mut self, _duration_in_seconds: u64) {
 
         //URL on which to start the wallet listener (i.e. api server)
       	let url = format!("{}:{}", self.config.base_addr, self.config.wallet_port);
-                
+
         //Just use the name of the server for a seed for now
         let seed = format!("{}", self.config.name);
 
@@ -277,18 +269,18 @@ impl LocalServerContainer {
 	    let s = Secp256k1::new();
 	    let key = wallet::ExtendedKey::from_seed(&s, seed.as_bytes())
 		         .expect("Error deriving extended key from seed.");
-        
+
         println!("Starting the Grin wallet receiving daemon on {} ", self.config.wallet_port );
 
         let mut wallet_config = WalletConfig::default();
-        
+
         wallet_config.api_http_addr = format!("http://{}", url);
         wallet_config.check_node_api_http_addr = self.config.wallet_validating_node_url.clone();
-        wallet_config.data_file_dir=self.working_dir.clone();        
+        wallet_config.data_file_dir=self.working_dir.clone();
 
         let mut api_server = api::ApiServer::new("/v1".to_string());
-	  
-	    api_server.register_endpoint("/receive".to_string(), wallet::WalletReceiver { 
+
+	    api_server.register_endpoint("/receive".to_string(), wallet::WalletReceiver {
             key: key,
             config: wallet_config,
         });
@@ -301,9 +293,9 @@ impl LocalServerContainer {
         self.wallet_is_running = true;
 
     }
-    
+
     /// Stops the running wallet server
-    
+
     pub fn stop_wallet(&mut self){
         let mut api_server = self.api_server.as_mut().unwrap();
         api_server.stop();
@@ -314,7 +306,7 @@ impl LocalServerContainer {
     pub fn add_peer(&mut self, addr:String){
         self.peer_list.push(addr);
     }
-    
+
 }
 
 /// Configuration values for container pool
@@ -428,16 +420,16 @@ impl LocalServerContainerPool {
             self.is_seeding=true;
         }
 
-        let server_address = format!("{}:{}",
-                                     server_config.base_addr,
-                                     server_config.p2p_server_port);
+        let _server_address = format!("{}:{}",
+                                      server_config.base_addr,
+                                      server_config.p2p_server_port);
 
-        let mut server_container = LocalServerContainer::new(server_config.clone()).unwrap();
+        let server_container = LocalServerContainer::new(server_config.clone()).unwrap();
         //self.server_containers.push(server_arc);
 
         //Create a future that runs the server for however many seconds
         //collect them all and run them in the run_all_servers
-        let run_time = self.config.run_length_in_seconds;
+        let _run_time = self.config.run_length_in_seconds;
 
         self.server_containers.push(server_container);
 
@@ -447,9 +439,9 @@ impl LocalServerContainerPool {
     /// adds n servers, ready to run
     ///
     ///
-
+    #[allow(dead_code)]
     pub fn create_servers(&mut self, number: u16){
-        for n in 0..number {
+        for _ in 0..number {
             //self.create_server();
         }
     }
@@ -489,7 +481,7 @@ impl LocalServerContainerPool {
 
         for handle in handles {
             match handle.join() {
-                Ok(v) => {}
+                Ok(_) => {}
                 Err(e) => {
                     println!("Error starting server thread: {:?}", e);
                     panic!(e);

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -25,9 +25,6 @@ extern crate futures;
 extern crate tokio_core;
 extern crate tokio_timer;
 
-use std::sync::{Arc, Mutex, RwLock};
-use std::fs;
-
 mod framework;
 
 use std::thread;
@@ -35,7 +32,7 @@ use std::time;
 use std::default::Default;
 
 use futures::{Future, Poll, Async};
-use futures::task::park;
+use futures::task::current;
 use tokio_core::reactor;
 use tokio_timer::Timer;
 
@@ -51,7 +48,7 @@ use framework::{LocalServerContainer, LocalServerContainerConfig, LocalServerCon
 /// Block and mining into a wallet for a bit
 #[test]
 fn basic_genesis_mine() {
-	env_logger::init();
+    let _ = env_logger::init();
     global::set_mining_mode(MiningParameterMode::AutomatedTesting);
 
 	let test_name_dir = "genesis_mine";
@@ -82,7 +79,7 @@ fn basic_genesis_mine() {
 /// messages they all end up connected.
 #[test]
 fn simulate_seeding() {
-	env_logger::init();
+    let _ = env_logger::init();
     global::set_mining_mode(MiningParameterMode::AutomatedTesting);
 
 	let test_name_dir = "simulate_seeding";
@@ -116,13 +113,13 @@ fn simulate_seeding() {
 		server_config.p2p_server_port
 	));
 
-	for i in 0..4 {
-		pool.create_server(&mut server_config);
-	}
+    for _ in 0..4 {
+        pool.create_server(&mut server_config);
+    }
 
 	pool.connect_all_peers();
 
-	let result_vec = pool.run_all_servers();
+    let _ = pool.run_all_servers();
 }
 
 /// Create 1 server, start it mining, then connect 4 other peers mining and
@@ -136,8 +133,9 @@ fn simulate_seeding() {
 // being,
 // As it's more for actively testing and hurts CI a lot
 //#[test]
+#[allow(dead_code)]
 fn simulate_parallel_mining() {
-	env_logger::init();
+    let _ = env_logger::init();
     global::set_mining_mode(MiningParameterMode::AutomatedTesting);
 
 	let test_name_dir = "simulate_parallel_mining";
@@ -179,7 +177,7 @@ fn simulate_parallel_mining() {
 
 	pool.connect_all_peers();
 
-	let result_vec = pool.run_all_servers();
+    let _ = pool.run_all_servers();
 
 	// Check mining difficulty here?, though I'd think it's more valuable
 	// to simply output it. Can at least see the evolution of the difficulty target

--- a/grin/tests/simulnet.rs
+++ b/grin/tests/simulnet.rs
@@ -333,7 +333,7 @@ impl<'a> Future for HeadChange<'a> {
 			Ok(Async::Ready(new_head))
 		} else {
 			// egregious polling, asking the task to schedule us every iteration
-			park().unpark();
+			current().notify();
 			Ok(Async::NotReady)
 		}
 	}

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -24,12 +24,12 @@ use futures;
 use futures::{Stream, Future};
 use futures::stream;
 use futures::sync::mpsc::{Sender, UnboundedSender, UnboundedReceiver};
-use tokio_core::io::{WriteHalf, ReadHalf, write_all, read_exact};
+use tokio_core::io::{write_all, read_exact};
 use tokio_core::net::TcpStream;
 use tokio_timer::{Timer, TimerError};
 use tokio_io::*;
 
-use core::core::hash::{Hash, ZERO_HASH};
+use core::core::hash::Hash;
 use core::ser;
 use msg::*;
 use types::Error;
@@ -65,6 +65,7 @@ impl<F> Handler for F
 /// A higher level connection wrapping the TcpStream. Maintains the amount of
 /// data transmitted and deals with the low-level task of sending and
 /// receiving data, parsing message headers and timeouts.
+#[allow(dead_code)]
 pub struct Connection {
 	// Channel to push bytes to the remote peer
 	outbound_chan: UnboundedSender<Vec<u8>>,
@@ -150,7 +151,7 @@ impl Connection {
 			})
       // write the data and make sure the future returns the right types
 			.fold(writer, |writer, data| {
-        write_all(writer, data).map_err(|e| Error::Connection(e)).map(|(writer, buf)| writer)
+        write_all(writer, data).map_err(|e| Error::Connection(e)).map(|(writer, _)| writer)
       });
 		Box::new(send_data)
 	}
@@ -287,7 +288,7 @@ impl TimeoutConnection {
 			underlying: conn,
 			expected_responses: expects,
 		};
-		(me, Box::new(fut.select(timer).map(|_| ()).map_err(|(e1, e2)| e1)))
+		(me, Box::new(fut.select(timer).map(|_| ()).map_err(|(e1, _)| e1)))
 	}
 
 	/// Sends a request and registers a timer on the provided message type and
@@ -298,7 +299,7 @@ impl TimeoutConnection {
 	                                       body: &W,
 	                                       expect_h: Option<(Hash)>)
 	                                       -> Result<(), Error> {
-		let sent = try!(self.underlying.send_msg(t, body));
+		let _sent = try!(self.underlying.send_msg(t, body));
 
 		let mut expects = self.expected_responses.lock().unwrap();
 		expects.push((rt, expect_h, Instant::now()));

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -24,10 +24,10 @@ use futures;
 use futures::{Stream, Future};
 use futures::stream;
 use futures::sync::mpsc::{Sender, UnboundedSender, UnboundedReceiver};
-use tokio_core::io::{write_all, read_exact};
 use tokio_core::net::TcpStream;
+use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_io::io::{read_exact, write_all};
 use tokio_timer::{Timer, TimerError};
-use tokio_io::*;
 
 use core::core::hash::Hash;
 use core::ser;

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -31,7 +31,6 @@ extern crate grin_util as util;
 #[macro_use]
 extern crate log;
 extern crate futures;
-#[macro_use]
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate bytes;

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -19,7 +19,7 @@ use num::FromPrimitive;
 
 use futures::future::{Future, ok};
 use tokio_core::net::TcpStream;
-use tokio_core::io::{write_all, read_exact};
+use tokio_io::io::{read_exact, write_all};
 
 use core::consensus::MAX_MSG_LEN;
 use core::core::BlockHeader;

--- a/p2p/src/msg.rs
+++ b/p2p/src/msg.rs
@@ -42,6 +42,7 @@ const MAGIC: [u8; 2] = [0x1e, 0xc5];
 pub const HEADER_LEN: u64 = 11;
 
 /// Codes for each error that can be produced reading a message.
+#[allow(dead_code)]
 pub enum ErrCodes {
 	UnsupportedVersion = 100,
 }
@@ -105,12 +106,12 @@ pub fn write_msg<T>(conn: TcpStream,
 	let write_msg = ok((conn)).and_then(move |conn| {
 		// prepare the body first so we know its serialized length
 		let mut body_buf = vec![];
-		ser::serialize(&mut body_buf, &msg);
+		ser::serialize(&mut body_buf, &msg).unwrap();
 
 		// build and serialize the header using the body size
 		let mut header_buf = vec![];
 		let blen = body_buf.len() as u64;
-		ser::serialize(&mut header_buf, &MsgHeader::new(msg_type, blen));
+		ser::serialize(&mut header_buf, &MsgHeader::new(msg_type, blen)).unwrap();
 
 		// send the whole thing
 		write_all(conn, header_buf)
@@ -202,9 +203,9 @@ impl Writeable for Hand {
 		                [write_u32, self.version],
 		                [write_u32, self.capabilities.bits()],
 		                [write_u64, self.nonce]);
-		self.total_difficulty.write(writer);
-		self.sender_addr.write(writer);
-		self.receiver_addr.write(writer);
+		self.total_difficulty.write(writer).unwrap();
+		self.sender_addr.write(writer).unwrap();
+		self.receiver_addr.write(writer).unwrap();
 		writer.write_bytes(&self.user_agent)
 	}
 }
@@ -250,8 +251,8 @@ impl Writeable for Shake {
 		ser_multiwrite!(writer,
 		                [write_u32, self.version],
 		                [write_u32, self.capabilities.bits()]);
-		self.total_difficulty.write(writer);
-		writer.write_bytes(&self.user_agent);
+		self.total_difficulty.write(writer).unwrap();
+		writer.write_bytes(&self.user_agent).unwrap();
 		Ok(())
 	}
 }
@@ -302,7 +303,7 @@ impl Writeable for PeerAddrs {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
 		try!(writer.write_u32(self.peers.len() as u32));
 		for p in &self.peers {
-			p.write(writer);
+			p.write(writer).unwrap();
 		}
 		Ok(())
 	}
@@ -464,13 +465,13 @@ impl Readable for Headers {
 pub struct Empty {}
 
 impl Writeable for Empty {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ser::Error> {
+	fn write<W: Writer>(&self, _: &mut W) -> Result<(), ser::Error> {
 		Ok(())
 	}
 }
 
 impl Readable for Empty {
-	fn read(reader: &mut Reader) -> Result<Empty, ser::Error> {
+	fn read(_: &mut Reader) -> Result<Empty, ser::Error> {
 		Ok(Empty {})
 	}
 }

--- a/p2p/src/peer.rs
+++ b/p2p/src/peer.rs
@@ -91,7 +91,7 @@ impl Peer {
 			// handle disconnection, standard disconnections aren't considered an error
 			let mut state = state.write().unwrap();
 			match res {
-				Ok(res) => {
+				Ok(_) => {
 					*state = State::Disconnected;
 					info!("Client {} disconnected.", addr);
 					Ok(())

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -14,9 +14,7 @@
 
 use std::sync::{Mutex, Arc};
 
-use futures;
 use futures::Future;
-use futures::stream;
 use futures::sync::mpsc::UnboundedSender;
 use tokio_core::net::TcpStream;
 
@@ -28,6 +26,7 @@ use msg::*;
 use types::*;
 use util::OneTime;
 
+#[allow(dead_code)]
 pub struct ProtocolV1 {
 	conn: OneTime<TimeoutConnection>,
 
@@ -128,7 +127,7 @@ fn handle_payload(adapter: &NetAdapter,
 	match header.msg_type {
 		Type::Ping => {
 			let data = ser::ser_vec(&MsgHeader::new(Type::Pong, 0))?;
-			sender.send(data);
+			sender.send(data).unwrap();
 			Ok(None)
 		}
 		Type::Pong => Ok(None),
@@ -148,7 +147,7 @@ fn handle_payload(adapter: &NetAdapter,
 				try!(ser::serialize(&mut data,
 				                    &MsgHeader::new(Type::Block, body_data.len() as u64)));
 				data.append(&mut body_data);
-				sender.send(data);
+				sender.send(data).unwrap();
 			}
 			Ok(None)
 		}
@@ -170,7 +169,7 @@ fn handle_payload(adapter: &NetAdapter,
 			try!(ser::serialize(&mut data,
 			                    &MsgHeader::new(Type::Headers, body_data.len() as u64)));
 			data.append(&mut body_data);
-			sender.send(data);
+			sender.send(data).unwrap();
 
 			Ok(None)
 		}
@@ -193,7 +192,7 @@ fn handle_payload(adapter: &NetAdapter,
 			try!(ser::serialize(&mut data,
 			                    &MsgHeader::new(Type::PeerAddrs, body_data.len() as u64)));
 			data.append(&mut body_data);
-			sender.send(data);
+			sender.send(data).unwrap();
 
 			Ok(None)
 		}

--- a/p2p/src/rate_limit.rs
+++ b/p2p/src/rate_limit.rs
@@ -14,12 +14,11 @@
 
 //! Provides wrappers for throttling readers and writers
 
-use std::time::{Instant, Duration};
+use std::time::Instant;
 use std::io;
 
 use futures::*;
 use tokio_io::*;
-use bytes::{Buf, BytesMut, BufMut};
 
 /// A Rate Limited Reader
 #[derive(Debug)]
@@ -32,6 +31,7 @@ pub struct ThrottledReader<R: AsyncRead> {
 	last_check: Instant,
 }
 
+#[allow(dead_code)]
 impl<R: AsyncRead> ThrottledReader<R> {
 	/// Adds throttling to a reader.
 	/// The resulting reader will read at most `max` amount of bytes per second
@@ -105,6 +105,7 @@ pub struct ThrottledWriter<W: AsyncWrite> {
 	last_check: Instant,
 }
 
+#[allow(dead_code)]
 impl<W: AsyncWrite> ThrottledWriter<W> {
 	/// Adds throttling to a writer.
 	/// The resulting writer will write at most `max` amount of bytes per second
@@ -188,7 +189,7 @@ mod test {
 		for _ in 0..16 {
 			let _ = t_buf.write_buf(&mut Cursor::new(vec![1; 8]));
 		}
-		
+
 		let cursor = t_buf.into_inner();
 		assert_eq!(cursor.position(), 8);
 	}
@@ -203,7 +204,7 @@ mod test {
 		for _ in 0..16 {
 			let _ = t_buf.read_buf(&mut dst);
 		}
-		
+
 		assert_eq!(dst.position(), 8);
 	}
 }

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -275,8 +275,7 @@ impl Server {
 		for p in peers.deref() {
 			p.stop();
 		}
-		// TODO - complete() deprecated but needs an unwrap()?
-		self.stop.into_inner().unwrap().complete(());
+		self.stop.into_inner().unwrap().send(()).unwrap();
 	}
 }
 

--- a/p2p/src/server.rs
+++ b/p2p/src/server.rs
@@ -41,20 +41,20 @@ impl NetAdapter for DummyAdapter {
 	fn total_difficulty(&self) -> Difficulty {
 		Difficulty::one()
 	}
-	fn transaction_received(&self, tx: core::Transaction) {}
-	fn block_received(&self, b: core::Block) {}
-	fn headers_received(&self, bh: Vec<core::BlockHeader>) {}
-	fn locate_headers(&self, locator: Vec<Hash>) -> Vec<core::BlockHeader> {
+	fn transaction_received(&self, _: core::Transaction) {}
+	fn block_received(&self, _: core::Block) {}
+	fn headers_received(&self, _: Vec<core::BlockHeader>) {}
+	fn locate_headers(&self, _: Vec<Hash>) -> Vec<core::BlockHeader> {
 		vec![]
 	}
-	fn get_block(&self, h: Hash) -> Option<core::Block> {
+	fn get_block(&self, _: Hash) -> Option<core::Block> {
 		None
 	}
-	fn find_peer_addrs(&self, capab: Capabilities) -> Vec<SocketAddr> {
+	fn find_peer_addrs(&self, _: Capabilities) -> Vec<SocketAddr> {
 		vec![]
 	}
-	fn peer_addrs_received(&self, peer_addrs: Vec<SocketAddr>) {}
-	fn peer_connected(&self, pi: &PeerInfo) {}
+	fn peer_addrs_received(&self, _: Vec<SocketAddr>) {}
+	fn peer_connected(&self, _: &PeerInfo) {}
 }
 
 /// P2P server implementation, handling bootstrapping to find and connect to
@@ -97,7 +97,7 @@ impl Server {
 
 		// main peer acceptance future handling handshake
 		let hp = h.clone();
-		let peers = socket.incoming().map_err(From::from).map(move |(conn, addr)| {
+		let peers = socket.incoming().map_err(From::from).map(move |(conn, _)| {
 			let adapter = adapter.clone();
 			let total_diff = adapter.total_difficulty();
 			let peers = peers.clone();
@@ -275,6 +275,7 @@ impl Server {
 		for p in peers.deref() {
 			p.stop();
 		}
+		// TODO - complete() deprecated but needs an unwrap()?
 		self.stop.into_inner().unwrap().complete(());
 	}
 }

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -33,6 +33,7 @@ pub const MAX_LOCATORS: u32 = 10;
 pub const MAX_BLOCK_HEADERS: u32 = 512;
 
 /// Maximum number of block bodies a peer should ever ask for and send
+#[allow(dead_code)]
 pub const MAX_BLOCK_BODIES: u32 = 16;
 
 /// Maximum number of peer addresses a peer should ever send
@@ -57,7 +58,7 @@ impl From<io::Error> for Error {
 	}
 }
 impl From<TimerError> for Error {
-	fn from(e: TimerError) -> Error {
+	fn from(_: TimerError) -> Error {
 		Error::Timeout
 	}
 }

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -26,7 +26,6 @@ use futures::future::Future;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::{self, Core};
 
-use core::ser;
 use core::core::target::Difficulty;
 use p2p::Peer;
 

--- a/pool/src/blockchain.rs
+++ b/pool/src/blockchain.rs
@@ -1,7 +1,7 @@
 // This file is (hopefully) temporary.
 //
 // It contains a trait based on (but not exactly equal to) the trait defined
-// for the blockchain UTXO set, discussed at 
+// for the blockchain UTXO set, discussed at
 // https://github.com/ignopeverell/grin/issues/29, and a dummy implementation
 // of said trait.
 // Notably, UtxoDiff has been left off, and the question of how to handle
@@ -20,11 +20,12 @@ use std::sync::RwLock;
 
 use types::BlockChain;
 
-/// A DummyUtxoSet for mocking up the chain 
+/// A DummyUtxoSet for mocking up the chain
 pub struct DummyUtxoSet {
     outputs : HashMap<Commitment, transaction::Output>
 }
 
+#[allow(dead_code)]
 impl DummyUtxoSet {
     pub fn empty() -> DummyUtxoSet{
         DummyUtxoSet{outputs: HashMap::new()}
@@ -50,7 +51,7 @@ impl DummyUtxoSet {
             self.outputs.insert(output.commitment(), output.clone());
         }
     }
-    pub fn rewind(&self, b: &block::Block) -> DummyUtxoSet {
+    pub fn rewind(&self, _: &block::Block) -> DummyUtxoSet {
         DummyUtxoSet{outputs: HashMap::new()}
     }
     pub fn get_output(&self, output_ref: &Commitment) -> Option<&transaction::Output> {
@@ -75,10 +76,12 @@ impl DummyUtxoSet {
 
 /// A DummyChain is the mocked chain for playing with what methods we would
 /// need
+#[allow(dead_code)]
 pub struct DummyChainImpl {
     utxo: RwLock<DummyUtxoSet>
 }
 
+#[allow(dead_code)]
 impl DummyChainImpl {
     pub fn new() -> DummyChainImpl {
         DummyChainImpl{

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -28,7 +28,6 @@ mod pool;
 
 extern crate time;
 extern crate rand;
-#[macro_use]
 extern crate log;
 
 extern crate grin_core as core;

--- a/secp256k1zkp/src/pedersen.rs
+++ b/secp256k1zkp/src/pedersen.rs
@@ -143,6 +143,7 @@ impl AsRef<[u8]> for RangeProof {
 }
 
 impl RangeProof {
+    /// Create the zero range proof
 	pub fn zero() -> RangeProof {
 		RangeProof {
 			proof: [0; constants::MAX_PROOF_SIZE],

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -187,6 +187,8 @@ impl<'a> Batch<'a> {
 		}
 	}
 
+	/// Delete a single key from the batch. The write function
+	/// must be called to "commit" the batch to storage.
 	pub fn delete(mut self, key: &[u8]) -> Result<Batch<'a>, Error> {
 		self.batch.delete(key)?;
 		Ok(self)

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -29,7 +29,7 @@ pub fn refresh_outputs(config: &WalletConfig, ext_key: &ExtendedKey) {
 	let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
 
 	// operate within a lock on wallet data
-	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
+	let _ = WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
 
 		// check each output that's not spent
 		for out in &mut wallet_data.outputs {
@@ -41,7 +41,7 @@ pub fn refresh_outputs(config: &WalletConfig, ext_key: &ExtendedKey) {
 				// TODO check the pool for unconfirmed
 
 				let out_res = get_output_by_commitment(config, commitment);
-		
+
 				if out_res.is_ok() {
 					// output is known, it's a new utxo
 					out.status = OutputStatus::Unspent;

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -50,13 +50,13 @@
 //! So we may as well have it in place already.
 
 use std::convert::From;
-use secp::{self, Secp256k1};
+use secp::{self};
 use secp::key::SecretKey;
 
 use core::core::{Block, Transaction, TxKernel, Output, build};
 use core::ser;
 use api::{self, ApiEndpoint, Operation, ApiResult};
-use extkey::{self, ExtendedKey};
+use extkey::ExtendedKey;
 use types::*;
 use util;
 
@@ -70,13 +70,13 @@ struct TxWrapper {
 /// transaction, adding our receiving output, to broadcast to the rest of the
 /// network.
 pub fn receive_json_tx(config: &WalletConfig, ext_key: &ExtendedKey, partial_tx_str: &str) -> Result<(), Error> {
-	
+
 	let (amount, blinding, partial_tx) = partial_tx_from_json(partial_tx_str)?;
 	let final_tx = receive_transaction(&config, ext_key, amount, blinding, partial_tx)?;
 	let tx_hex = util::to_hex(ser::ser_vec(&final_tx).unwrap());
 
 	let url = format!("{}/v1/pool/push", config.check_node_api_http_addr.as_str());
-	api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex })?;
+	let _: TxWrapper = api::client::post(url.as_str(), &TxWrapper { tx_hex: tx_hex })?;
 	Ok(())
 }
 
@@ -135,9 +135,9 @@ impl ApiEndpoint for WalletReceiver {
 					WalletReceiveRequest::PartialTransaction(partial_tx_str) => {
 						debug!("Operation {} with transaction {}", op, &partial_tx_str);
 						receive_json_tx(&self.config, &self.key, &partial_tx_str).map_err(|e| {
-									api::Error::Internal(format!("Error processing partial transaction: {:?}", e))
-								});
-						
+							api::Error::Internal(format!("Error processing partial transaction: {:?}", e))
+						}).unwrap();
+
 						//TODO: Return emptiness for now, should be a proper enum return type
 						Ok(CbData {
 							output: String::from(""),

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::convert::From;
-use secp::{self, Secp256k1};
+use secp::{self};
 use secp::key::SecretKey;
 
 use checker;
@@ -29,21 +29,18 @@ use api;
 /// recipients wallet receiver (to be implemented).
 pub fn issue_send_tx(config: &WalletConfig, ext_key: &ExtendedKey, amount: u64, dest: String) -> Result<(), Error> {
 	checker::refresh_outputs(&config, ext_key);
-	
+
 	let (tx, blind_sum) = build_send_tx(config, ext_key, amount)?;
 	let json_tx = partial_tx_to_json(amount, blind_sum, tx);
-	
+
 	if dest == "stdout" {
 		println!("{}", json_tx);
 	} else if &dest[..4] == "http" {
-		let url = format!("{}/v1/receive/receive_json_tx",
-			                  &dest);
+		let url = format!("{}/v1/receive/receive_json_tx", &dest);
 		debug!("Posting partial transaction to {}", url);
 		let request = WalletReceiveRequest::PartialTransaction(json_tx);
-		let res: CbData = api::client::post(url.as_str(),
-			                                    &request)
-				.expect(&format!("Wallet receiver at {} unreachable, could not send transaction. Is it running?", url));
-			
+		let _: CbData = api::client::post(url.as_str(), &request)
+			.expect(&format!("Wallet receiver at {} unreachable, could not send transaction. Is it running?", url));
 	}
 	Ok(())
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -65,7 +65,7 @@ impl From<serde_json::Error> for Error {
 }
 
 impl From<num::ParseIntError> for Error {
-	fn from(e: num::ParseIntError) -> Error {
+	fn from(_: num::ParseIntError) -> Error {
 		Error::Format("Invalid hex".to_string())
 	}
 }
@@ -91,7 +91,7 @@ pub struct WalletConfig {
 
 impl Default for WalletConfig {
 	fn default() -> WalletConfig {
-		WalletConfig { 
+		WalletConfig {
 			enable_wallet: false,
 			api_http_addr: "http://127.0.0.1:13415".to_string(),
 			check_node_api_http_addr: "http://127.0.0.1:13415".to_string(),
@@ -161,12 +161,12 @@ impl WalletData {
 		fs::create_dir_all(data_file_dir).unwrap_or_else(|why| {
         	info!("! {:?}", why.kind());
     	});
-		
+
 		let data_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, DAT_FILE);
 		let lock_file_path = &format!("{}{}{}", data_file_dir, MAIN_SEPARATOR, LOCK_FILE);
 
 		// create the lock files, if it already exists, will produce an error
-    	OpenOptions::new().write(true).create_new(true).open(lock_file_path).map_err(|e| {
+    	OpenOptions::new().write(true).create_new(true).open(lock_file_path).map_err(|_| {
 				Error::WalletData(format!("Could not create wallet lock file. Either \
             some other process is using the wallet or there's a write access \
             issue."))
@@ -178,7 +178,7 @@ impl WalletData {
 		wdat.write(data_file_path)?;
 
 		// delete the lock file
-		fs::remove_file(lock_file_path).map_err(|e| {
+		fs::remove_file(lock_file_path).map_err(|_| {
 				Error::WalletData(format!("Could not remove wallet lock file. Maybe insufficient \
 				                           rights?"))
 			})?;


### PR DESCRIPTION
Took some time to clean up some `cargo build` warnings - let me know if you think is worth spending a bit of time on. 

I'm taking some time to get familiar with the code and would like to contribute if I can.

Ideally these will all run cleanly without warnings - 

- [x] `cargo build -p grin_api`
- [x] `cargo test -p grin_api`
- [x] `cargo build -p grin_chain`
- [x] `cargo test -p grin_chain`
- [x] `cargo build -p grin_core`
- [x] `cargo test -p grin_core`
- [x] `cargo build -p grin_p2p`
- [x] `cargo test -p grin_p2p`
- [x] `cargo build -p grin_pool`
- [x] `cargo test -p grin_pool`
- [x] `cargo build -p grin_config`
- [x] `cargo test -p grin_config` <- not actively in use?
- [x] `cargo build -p grin_grin`
- [x] `cargo test -p grin_grin`
- [x] `src`
- [x] `util`
- [x] `wallet`


