### PR TITLE
cleanup build warnings - unused vars

### DIFF
--- a/api/src/endpoints.rs
+++ b/api/src/endpoints.rs
@@ -51,7 +51,7 @@ impl ApiEndpoint for ChainApi {
 		vec![Operation::Get]
 	}
 
-	fn get(&self, id: String) -> ApiResult<Tip> {
+	fn get(&self, _: String) -> ApiResult<Tip> {
 		self.chain.head().map_err(|e| Error::Internal(format!("{:?}", e)))
 	}
 }
@@ -75,7 +75,7 @@ impl ApiEndpoint for OutputApi {
 
 	fn get(&self, id: String) -> ApiResult<Output> {
 		debug!("GET output {}", id);
-		let c = util::from_hex(id.clone()).map_err(|e| Error::Argument(format!("Not a valid commitment: {}", id)))?;
+		let c = util::from_hex(id.clone()).map_err(|_| Error::Argument(format!("Not a valid commitment: {}", id)))?;
 
     match self.chain.get_unspent(&Commitment::from_vec(c)) {
       Some(utxo) => Ok(utxo),
@@ -111,7 +111,7 @@ impl<T> ApiEndpoint for PoolApi<T>
 		vec![Operation::Get, Operation::Custom("push".to_string())]
 	}
 
-	fn get(&self, id: String) -> ApiResult<PoolInfo> {
+	fn get(&self, _: String) -> ApiResult<PoolInfo> {
 		let pool = self.tx_pool.read().unwrap();
 		Ok(PoolInfo {
 			pool_size: pool.pool_size(),
@@ -120,9 +120,9 @@ impl<T> ApiEndpoint for PoolApi<T>
 		})
 	}
 
-	fn operation(&self, op: String, input: TxWrapper) -> ApiResult<()> {
+	fn operation(&self, _: String, input: TxWrapper) -> ApiResult<()> {
 		let tx_bin = util::from_hex(input.tx_hex)
-      .map_err(|e| Error::Argument(format!("Invalid hex in transaction wrapper.")))?;
+      .map_err(|_| Error::Argument(format!("Invalid hex in transaction wrapper.")))?;
 
 		let tx: Transaction = ser::deserialize(&mut &tx_bin[..]).map_err(|_| {
 				Error::Argument("Could not deserialize transaction, invalid format.".to_string())


### PR DESCRIPTION
Get rid of some "unused variable" build warnings via `_`.
