### PR TITLE
add "cache: cargo" to travis config (significantly faster build times)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+cache: cargo
 dist: trusty
 sudo: true
 rust:


### PR DESCRIPTION
I looked through the history of the travis config file and the project issues and saw nothing to indicate this has already been tried - so I'm assuming there is no obvious reason not to do this?

Enable the cargo build cache in travis config file.
This caches `$HOME/.cargo` and `$TRAVIS_BUILD_DIR/target` dirs so we can avoid having to recompile all libs each time.

https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache

Before - 

<img width="1074" alt="screen shot 2017-08-10 at 10 43 44 am" src="https://user-images.githubusercontent.com/30642645/29176151-0772877a-7db9-11e7-8df9-e8245b65b8ff.png">

After (with cache) - 

<img width="1072" alt="screen shot 2017-08-10 at 10 44 06 am" src="https://user-images.githubusercontent.com/30642645/29176163-145b3cc0-7db9-11e7-997a-2ecef98126df.png">

See https://github.com/travis-ci/travis-ci/issues/4470 for some details of why this *should* be safe even across multiple rust versions (cache is separated by rust version and branch).





