### PR TITLE
Cuckoo miner with cmake update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-5
+      - cmake
 
 env:
   global:

--- a/doc/build.md
+++ b/doc/build.md
@@ -8,6 +8,12 @@
 or see instructions at:
 https://www.rust-lang.org
 
+## Install cmake
+
+grin needs cmake 3.8 or greater to compile the mining plugins found in [Cuckoo Miner](https://github.com/mimblewimble/cuckoo-miner). See
+your distribution's instructions for ensuring cmake is installed and
+available on the path.  
+
 ## Clone Grin
 
     git clone https://github.com/ignopeverell/grin.git

--- a/grin.toml
+++ b/grin.toml
@@ -80,6 +80,7 @@ cuckoo_miner_async_mode = false
 #Plugins currently included are:
 #"simple" : the basic cuckoo algorithm
 #"edgetrim" : an algorithm trading speed for a much lower memory footprint
+#"matrix" : fastest available CPU miner, with largest memory footprint
 #"tomato" : Time memory-tradeoff... low memory but very slow
 #Not included but verified working:
 #"cuda" a gpu miner - which currently needs to bebuilt and installed 
@@ -87,7 +88,7 @@ cuckoo_miner_async_mode = false
 
 cuckoo_miner_plugin_type = "simple"
 
-#the list of parameters if you're using "edgetrim"
+#the list of parameters if you're using "edgetrim or matrix"
 #cuckoo_miner_parameter_list = {NUM_THREADS=4, NUM_TRIMS=7}
 
 #The amount of time, in seconds, to attempt to mine on a particular

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "~0.2.8"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 
-cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration_6"}
+cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration_7"}
 #cuckoo_miner = { path = "../../cuckoo-miner"}
 
 grin_core = { path = "../core" }

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "~0.2.8"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 
-cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration_7"}
+cuckoo_miner = { git = "https://github.com/mimblewimble/cuckoo-miner", tag="grin_integration_8"}
 #cuckoo_miner = { path = "../../cuckoo-miner"}
 
 grin_core = { path = "../core" }

--- a/pow/src/plugin.rs
+++ b/pow/src/plugin.rs
@@ -74,7 +74,7 @@ impl PluginMiner {
 
 		let plugin_install_path = match miner_config.cuckoo_miner_plugin_dir {
 			Some(s) => s,
-			None => String::from(format!("{}/deps", exe_path))
+			None => String::from(format!("{}/plugins", exe_path))
 		};
 
 		let plugin_impl_filter = match miner_config.cuckoo_miner_plugin_type {
@@ -83,7 +83,7 @@ impl PluginMiner {
 		};
 
 		//First, load and query the plugins in the given directory
-		//These should all be stored in 'deps' at the moment relative
+		//These should all be stored in 'plugins' at the moment relative
 		//to the executable path, though they should appear somewhere else
 		//when packaging is more//thought out
 
@@ -102,7 +102,7 @@ impl PluginMiner {
     	let result=plugin_manager.load_plugin_dir(plugin_install_path);
 
 		if let Err(_) = result {
-			error!("Unable to load cuckoo-miner plugin directory, either from configuration or [exe_path]/deps.");
+			error!("Unable to load cuckoo-miner plugin directory, either from configuration or [exe_path]/plugins.");
 			panic!("Unable to load plugin directory... Please check configuration values");
 		}
 


### PR DESCRIPTION
Small one from grin's side to update to the latest cuckoo miner, which now uses cmake to build plugins. Notes:

-cmake now required to build grin on linux/osx, I thought this is probably not such a big ask in terms of a build dependency. I might need to play with the exact version required bit depending on the CI results.
-plugins will be built and place into target/debug/plugins on osx and linux, and will include cuda plugins if the cuda build environment is found. cuckoo-miner currently won't attempt to build the plugins on windows.
-Latest version of matrix miner is included, so CPU mining at cuckoo30 is now viable
-Docs changed to indicate cmake dependency.

Will see how travis likes the new cmake dependency, will adjust version if it doesn't like it. 

update, cmake version adjusted, so all good. 