### PR TITLE
Store block header hash by input and output commitment

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -265,6 +265,20 @@ impl Chain {
 		)
 	}
 
+    /// Gets the block header by the provided input commitment
+    pub fn get_block_header_by_input_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
+        self.store.get_block_header_by_input_commit(commit).map_err(
+            &Error::StoreErr,
+        )
+    }
+
+    /// Gets the block header by the provided output commitment
+    pub fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
+        self.store.get_block_header_by_output_commit(commit).map_err(
+            &Error::StoreErr,
+        )
+    }
+
 	/// Get the tip of the header chain
 	pub fn get_header_head(&self) -> Result<Tip, Error> {
 		self.store.get_header_head().map_err(&Error::StoreErr)

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -35,13 +35,13 @@ const MAX_ORPHANS: usize = 20;
 /// Helper macro to transform a Result into an Option with None in case
 /// of error
 macro_rules! none_err {
-  ($trying:expr) => {{
-    let tried = $trying;
-    if let Err(_) = tried {
-      return None;
-    }
-    tried.unwrap()
-  }}
+    ($trying:expr) => {{
+        let tried = $trying;
+        if let Err(_) = tried {
+            return None;
+        }
+        tried.unwrap()
+    }}
 }
 
 /// Facade to the blockchain block processing pipeline and storage. Provides
@@ -111,6 +111,7 @@ impl Chain {
 
         // TODO - confirm this was safe to remove based on code above?
 		// let head = chain_store.head()?;
+
 
 		Ok(Chain {
 			store: Arc::new(chain_store),
@@ -211,21 +212,14 @@ impl Chain {
 	}
 
 	/// Gets an unspent output from its commitment. With return None if the
-	/// output
-	/// doesn't exist or has been spent. This querying is done in a way that's
+	/// output doesn't exist or has been spent. This querying is done in a way that is
 	/// consistent with the current chain state and more specifically the
-	/// current
-	/// branch it is on in case of forks.
+	/// current branch it is on in case of forks.
 	pub fn get_unspent(&self, output_ref: &Commitment) -> Option<Output> {
-
-        // TODO - check this is safe to do based on comments above about chain state
-        // TODO - need to do some final check to ensure valid for current chain state?
-
-        // TODO - still trying to get my head around none_err! - maybe this helps here?
-
-        // basically look for a block header spending an input with the output commitment
-        // if we don't find one then the output is unspent
+        // this will only return a block header based on the current chain state
+        // as get_block_header_by_input_commit looks at the block heights
         let header = self.store.get_block_header_by_input_commit(output_ref);
+
         match header {
             Ok(_) => None,
             Err(NotFoundErr) => {

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -119,6 +119,20 @@ impl ChainStore for ChainKVStore {
 		batch.write()
 	}
 
+	fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
+		option_to_not_found(self.db.get_ser(&to_key(
+			HEADER_BY_OUTPUT_PREFIX,
+			&mut commit.as_ref().to_vec(),
+		)))
+	}
+
+	fn get_block_header_by_input_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
+		option_to_not_found(self.db.get_ser(&to_key(
+			HEADER_BY_INPUT_PREFIX,
+			&mut commit.as_ref().to_vec(),
+		)))
+	}
+
 	fn save_block_header(&self, bh: &BlockHeader) -> Result<(), Error> {
 		self.db.put_ser(&to_key(BLOCK_HEADER_PREFIX, &mut bh.hash().to_vec())[..], bh)
 	}
@@ -134,6 +148,8 @@ impl ChainStore for ChainKVStore {
 		)))
 	}
 
+	// TODO - this looks identical to get_output_by_commit above
+	// TODO - are we sure this returns a hash correctly?
 	fn has_output_commit(&self, commit: &Commitment) -> Result<Hash, Error> {
 		option_to_not_found(self.db.get_ser(&to_key(
 			OUTPUT_COMMIT_PREFIX,

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -134,27 +134,6 @@ impl ChainStore for ChainKVStore {
 		}
 	}
 
-	// TODO - this can probably be cleaned up and written closer to idiomatic rust
-	fn get_block_header_by_input_commit(&self, commit: &Commitment) -> Result<BlockHeader, Error> {
-		let block_hash = self.db.get_ser(&to_key(
-			HEADER_BY_INPUT_PREFIX,
-			&mut commit.as_ref().to_vec(),
-		))?;
-
-		match block_hash {
-			Some(hash) => {
-				let block_header = self.get_block_header(&hash)?;
-				let header_at_height = self.get_header_by_height(block_header.height)?;
-				if block_header.hash() == header_at_height.hash() {
-					Ok(block_header)
-				} else {
-					Err(Error::NotFoundErr)
-				}
-			},
-			None => Err(Error::NotFoundErr)
-		}
-	}
-
 	fn save_block_header(&self, bh: &BlockHeader) -> Result<(), Error> {
 		self.db.put_ser(&to_key(BLOCK_HEADER_PREFIX, &mut bh.hash().to_vec())[..], bh)
 	}

--- a/chain/src/store.rs
+++ b/chain/src/store.rs
@@ -100,19 +100,16 @@ impl ChainStore for ChainKVStore {
 
 		// input commitment to hash index
 		for inp in &b.inputs {
-			let mut inp_bytes = inp.commitment().as_ref().to_vec();
 			batch = batch
-				.put_ser(&to_key(HEADER_BY_INPUT_PREFIX, &mut inp_bytes)[..], &b.hash())?;
+				.put_ser(&to_key(HEADER_BY_INPUT_PREFIX, &mut inp.commitment().as_ref().to_vec())[..], &b.hash())?;
 		}
 
 		// saving the full output under its hash, as well as a commitment to hash index
 		for out in &b.outputs {
-			let mut out_bytes = out.commitment().as_ref().to_vec();
 			batch = batch
-				.put_ser(&to_key(OUTPUT_COMMIT_PREFIX, &mut out_bytes)[..], out)?
-				.put_ser(&to_key(HEADER_BY_OUTPUT_PREFIX, &mut out_bytes)[..], &b.hash())?;
+				.put_ser(&to_key(OUTPUT_COMMIT_PREFIX, &mut out.commitment().as_ref().to_vec())[..], out)?
+				.put_ser(&to_key(HEADER_BY_OUTPUT_PREFIX, &mut out.commitment().as_ref().to_vec())[..], &b.hash())?;
 		}
-
 		batch.write()
 	}
 
@@ -127,7 +124,7 @@ impl ChainStore for ChainKVStore {
 			Some(hash) => {
 				let block_header = self.get_block_header(&hash)?;
 				let header_at_height = self.get_header_by_height(block_header.height)?;
-				if block_header == header_at_height {
+				if block_header.hash() == header_at_height.hash() {
 					Ok(block_header)
 				} else {
 					Err(Error::NotFoundErr)

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -184,8 +184,14 @@ pub trait ChainStore: Send + Sync {
 	/// Gets an output by its commitment
 	fn get_output_by_commit(&self, commit: &Commitment) -> Result<Output, store::Error>;
 
-	/// Checks whether an output commitment exists and returns the output hash
-	fn has_output_commit(&self, commit: &Commitment) -> Result<Hash, store::Error>;
+    /// Checks whether an output commitment exists and returns the output hash
+    fn has_output_commit(&self, commit: &Commitment) -> Result<Hash, store::Error>;
+
+    /// Gets a block_header for the given output commit
+    fn get_block_header_by_input_commit(&self, commit: &Commitment) -> Result<BlockHeader, store::Error>;
+
+    /// Gets a block_header for the given input commit
+    fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, store::Error>;
 
 	/// Saves the provided block header at the corresponding height. Also check
 	/// the consistency of the height chain in store by assuring previous

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -187,9 +187,6 @@ pub trait ChainStore: Send + Sync {
     /// Checks whether an output commitment exists and returns the output hash
     fn has_output_commit(&self, commit: &Commitment) -> Result<Hash, store::Error>;
 
-    /// Gets a block_header for the given output commit
-    fn get_block_header_by_input_commit(&self, commit: &Commitment) -> Result<BlockHeader, store::Error>;
-
     /// Gets a block_header for the given input commit
     fn get_block_header_by_output_commit(&self, commit: &Commitment) -> Result<BlockHeader, store::Error>;
 

--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -86,6 +86,26 @@ fn mine_empty_chain() {
 		let head = chain.head().unwrap();
 		assert_eq!(head.height, n);
 		assert_eq!(head.last_block_h, bhash);
+
+        // now check the block_header of the head
+        let header = chain.head_header().unwrap();
+        assert_eq!(header.height, n);
+        assert_eq!(header.hash(), bhash);
+
+        // now check the block itself
+        let block = chain.get_block(&header.hash()).unwrap();
+        assert_eq!(block.header.height, n);
+        assert_eq!(block.hash(), bhash);
+        assert_eq!(block.outputs.len(), 1);
+
+        // now check the block height index
+        let header_by_height = chain.get_header_by_height(n).unwrap();
+        assert_eq!(header_by_height.hash(), bhash);
+
+        // now check the header output index
+        let output = block.outputs[0];
+        let header_by_output_commit = chain.get_block_header_by_output_commit(&output.commitment()).unwrap();
+        assert_eq!(header_by_output_commit.hash(), bhash);
 	}
 }
 

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -1,0 +1,78 @@
+// Copyright 2017 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+extern crate grin_chain as chain;
+extern crate grin_core as core;
+extern crate rand;
+extern crate secp256k1zkp as secp;
+
+use std::fs;
+
+use chain::ChainStore;
+use core::core::hash::Hashed;
+use core::core::{Block, BlockHeader};
+use core::core::build::{input_rand, output_rand, transaction};
+use secp::key;
+
+fn clean_output_dir(dir_name: &str) {
+	let _ = fs::remove_dir_all(dir_name);
+}
+
+#[test]
+fn test_various_store_indices() {
+	let _ = env_logger::init();
+	clean_output_dir(".grin");
+
+	let chain_store = &chain::store::ChainKVStore::new(".grin".to_string()).unwrap() as &ChainStore;
+
+	let block = Block::new(&BlockHeader::default(), vec![], key::ONE_KEY).unwrap();
+	let commit = block.outputs[0].commitment();
+	let block_hash = block.hash();
+
+	chain_store.save_block(&block).unwrap();
+	chain_store.setup_height(&block.header).unwrap();
+
+	let block_header = chain_store.get_block_header(&block_hash).unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+
+	let block_header = chain_store.get_header_by_height(1).unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+
+	let block_header = chain_store
+		.get_block_header_by_output_commit(&commit)
+		.unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+
+	let txn = transaction(vec![input_rand(5), output_rand(5)])
+		.map(|(tx, _)| tx)
+		.unwrap();
+	let block = Block::new(&block.header, vec![&txn], key::ONE_KEY).unwrap();
+	let commit = block.inputs[0].commitment();
+	let block_hash = block.hash();
+
+	chain_store.save_block(&block).unwrap();
+	chain_store.setup_height(&block.header).unwrap();
+
+	let block_header = chain_store.get_block_header(&block_hash).unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+
+	let block_header = chain_store.get_header_by_height(2).unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+
+	let block_header = chain_store
+		.get_block_header_by_input_commit(&commit)
+		.unwrap();
+	assert_eq!(block_header.hash(), block_hash);
+}

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -23,7 +23,6 @@ use std::fs;
 use chain::ChainStore;
 use core::core::hash::Hashed;
 use core::core::{Block, BlockHeader};
-use core::core::build::{input_rand, output_rand, transaction};
 use secp::key;
 
 fn clean_output_dir(dir_name: &str) {
@@ -52,27 +51,6 @@ fn test_various_store_indices() {
 
 	let block_header = chain_store
 		.get_block_header_by_output_commit(&commit)
-		.unwrap();
-	assert_eq!(block_header.hash(), block_hash);
-
-	let txn = transaction(vec![input_rand(5), output_rand(5)])
-		.map(|(tx, _)| tx)
-		.unwrap();
-	let block = Block::new(&block.header, vec![&txn], key::ONE_KEY).unwrap();
-	let commit = block.inputs[0].commitment();
-	let block_hash = block.hash();
-
-	chain_store.save_block(&block).unwrap();
-	chain_store.setup_height(&block.header).unwrap();
-
-	let block_header = chain_store.get_block_header(&block_hash).unwrap();
-	assert_eq!(block_header.hash(), block_hash);
-
-	let block_header = chain_store.get_header_by_height(2).unwrap();
-	assert_eq!(block_header.hash(), block_hash);
-
-	let block_header = chain_store
-		.get_block_header_by_input_commit(&commit)
 		.unwrap();
 	assert_eq!(block_header.hash(), block_hash);
 }

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -386,6 +386,12 @@ impl Writeable for [u8; 4] {
 	}
 }
 
+impl Writeable for Vec<u8> {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		writer.write_fixed_bytes(self)
+	}
+}
+
 /// Useful marker trait on types that can be sized byte slices
 pub trait AsFixedBytes: Sized + AsRef<[u8]> {
 	/// The length in bytes


### PR DESCRIPTION
This PR adds a new index to the chain store - storing block_headers (actually the block header hash) by output commitment.
This allows lookup of the block header by output commit for the purpose of verifying the block height is valid when spending a coinbase output (see #27).

* Index in store to allow block_header lookup by output commitment
* Check current chain state via the `get_header_by_height()` to double check the block_header is what we think it is
* added some test coverage around `get_block_header_by_output_commitment`

NOTE: this index is not exhaustive - we cannot guarantee every block header is in the index. We can (I believe) guarantee this for a recent period of time (2 months?).
This time period *is* long enough to verify a coinbase block height.

Q) Does checking the hash of the block_header stored via `get_header_by_height()` give us enough of a guarantee to be sure the current chain state is correct in `get_block_header_by_input_commit()` from `get_unspent()`? Is this even necessary?
