### PR TITLE
Use UTC in timestamps and fix broken header test

### DIFF
--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -130,7 +130,7 @@ fn validate_header(header: &BlockHeader, ctx: &mut BlockContext) -> Result<(), E
 		return Err(Error::InvalidBlockTime);
 	}
 	if header.timestamp >
-		time::now() + time::Duration::seconds(12 * (consensus::BLOCK_TIME_SEC as i64))
+		time::now_utc() + time::Duration::seconds(12 * (consensus::BLOCK_TIME_SEC as i64))
 	{
 		// refuse blocks more than 12 blocks intervals in future (as in bitcoin)
 		// TODO add warning in p2p code if local time is too different from peers

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -281,7 +281,7 @@ impl Block {
 		Ok(Block {
 				header: BlockHeader {
 					height: prev.height + 1,
-					timestamp: time::now(),
+					timestamp: time::Tm { tm_nsec: 0, ..time::now_utc() },
 					previous: prev.hash(),
 					total_difficulty: prev.pow.clone().to_difficulty() + prev.total_difficulty.clone(),
 					..Default::default()
@@ -632,10 +632,6 @@ mod test {
         assert_eq!(b.inputs, b2.inputs);
         assert_eq!(b.outputs, b2.outputs);
         assert_eq!(b.kernels, b2.kernels);
-
-        // TODO - timestamps are not coming back equal here (UTC related?) -
-        // assert_eq!(b.header, b2.header);
-        // timestamp: Tm { tm_sec: 51, tm_min: 7, tm_hour: 23, tm_mday: 20, tm_mon: 7, tm_year: 117, tm_wday: 0, tm_yday: 231, tm_isdst: 1, tm_utcoff: -14400, tm_nsec: 780878000 },
-        // timestamp: Tm { tm_sec: 51, tm_min: 7, tm_hour: 3, tm_mday: 21, tm_mon: 7, tm_year: 117, tm_wday: 1, tm_yday: 232, tm_isdst: 0, tm_utcoff: 0, tm_nsec: 0 },
+        assert_eq!(b.header, b2.header);
     }
 }

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -398,7 +398,7 @@ impl Miner {
 		let mut rng = rand::OsRng::new().unwrap();
 		b.header.nonce = rng.gen();
 		b.header.difficulty = difficulty;
-		b.header.timestamp = time::at(time::Timespec::new(now_sec, 0));
+		b.header.timestamp = time::at_utc(time::Timespec::new(now_sec, 0));
 		b
 	}
 

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -46,7 +46,7 @@ impl PoolEntry {
         PoolEntry{
             transaction_hash: transaction_identifier(tx),
             size_estimate : estimate_transaction_size(tx),
-            receive_ts: time::now()}
+            receive_ts: time::now_utc()}
     }
 }
 


### PR DESCRIPTION
babb6110c4a7014a631239420b44eba4f2c3b848 by @antiochp introduced a new TODO to fix a failing test of block headers. This PR implements the proper fix and also addresses the large cause.

The fix is two part:
1. The standard seems to be that timestamps are assumed to be at 0 nsec (which seems reasonable) but was being stored with non-zero values for `tm_nsec` in `time::Tm` objects.
2. `time::at()` was being called instead of `time::at_utc()`, and as such the time was not in UTC (as suggested by the TODO).

The second issue appears elsewhere in the code base as well, and so this PR addresses those instances also. In some cases, this fix will not be important in practice, but should be fixed nonetheless for uniformity.