### PR TITLE
run rustfmt from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,12 @@ env:
     - TEST_DIR=wallet
     - RUST_TEST_THREADS=1 TEST_DIR=grin
 
-script: cd $TEST_DIR && cargo test --verbose
+install:
+  - rustup install nightly
+  - which rustfmt || rustup run nightly cargo install rustfmt-nightly
+
+script:
+  - cd $TEST_DIR
+  - cargo +nightly fmt -- --write-mode=diff
+  - cargo build
+  - cargo test --verbose


### PR DESCRIPTION
One possible approach to "automating" `rustfmt` - run it via travis and fail the build if anything is not correctly formatted.
i.e. to keep things clean you would need to run rustmft locally before pushing to github.
This *may* be preferable to attempting to fully automate the running of `rustfmt`?

See - https://github.com/rust-lang-nursery/rustfmt#checking-style-on-a-ci-server

* `rustup install nightly` (needed for `rustfmt`)
* install `rustfmt-nightly`
* run `rustfmt` as part of the travis script

This causes the build to fail if `rustfmt` returns with anything other than 0.
But the rest of the build script will continue to execute (so we will still see test failures etc.)

