### PR TITLE
WIP: Prunable MMR storage

### DIFF
--- a/core/src/core/pmmr.rs
+++ b/core/src/core/pmmr.rs
@@ -396,7 +396,7 @@ impl PruneList {
 	/// Gets the position a new pruned node should take in the prune list.
 	/// If the node has already bee pruned, either directly or through one of
 	/// its parents contained in the prune list, returns None.
-	fn pruned_pos(&self, pos: u64) -> Option<usize> {
+	pub fn pruned_pos(&self, pos: u64) -> Option<usize> {
 		match self.pruned_nodes.binary_search(&pos) {
 			Ok(_) => None,
 			Err(idx) => {

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -410,12 +410,6 @@ impl Writeable for [u8; 4] {
 	}
 }
 
-impl Writeable for Vec<u8> {
-	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
-		writer.write_fixed_bytes(self)
-	}
-}
-
 /// Useful marker trait on types that can be sized byte slices
 pub trait AsFixedBytes: Sized + AsRef<[u8]> {
 	/// The length in bytes

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -342,6 +342,15 @@ impl<T> Readable for Vec<T> where T: Readable {
 	}
 }
 
+impl<T> Writeable for Vec<T> where T: Writeable {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		for elmt in self {
+			elmt.write(writer)?;
+		}
+		Ok(())
+	}
+}
+
 impl<'a, A: Writeable> Writeable for &'a A {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
 		Writeable::write(*self, writer)

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -12,3 +12,7 @@ memmap = { git = "https://github.com/danburkert/memmap-rs" }
 rocksdb = "^0.7.0"
 
 grin_core = { path = "../core" }
+
+[dev-dependencies]
+env_logger="^0.3.5"
+time = "^0.1"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -6,6 +6,9 @@ workspace = ".."
 
 [dependencies]
 byteorder = "^0.5"
+env_logger="^0.3.5"
+log = "^0.3"
+memmap = { git = "https://github.com/danburkert/memmap-rs" }
 rocksdb = "^0.7.0"
 
 grin_core = { path = "../core" }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -22,7 +22,13 @@
 
 extern crate byteorder;
 extern crate grin_core as core;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate memmap;
 extern crate rocksdb;
+
+mod sumtree;
 
 const SEP: u8 = ':' as u8;
 
@@ -39,23 +45,23 @@ use core::ser;
 /// Main error type for this crate.
 #[derive(Debug)]
 pub enum Error {
-	/// Couldn't find what we were looking for
-	NotFoundErr,
-	/// Wraps an error originating from RocksDB (which unfortunately returns
-	/// string errors).
-	RocksDbErr(String),
-	/// Wraps a serialization error for Writeable or Readable
-	SerErr(ser::Error),
+/// Couldn't find what we were looking for
+NotFoundErr,
+/// Wraps an error originating from RocksDB (which unfortunately returns
+/// string errors).
+RocksDbErr(String),
+/// Wraps a serialization error for Writeable or Readable
+SerErr(ser::Error),
 }
 
 impl fmt::Display for Error {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		match self {
-			&Error::NotFoundErr => write!(f, "Not Found"),
-			&Error::RocksDbErr(ref s) => write!(f, "RocksDb Error: {}", s),
-			&Error::SerErr(ref e) => write!(f, "Serialization Error: {}", e.to_string()),
-		}
+fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	match self {
+		&Error::NotFoundErr => write!(f, "Not Found"),
+		&Error::RocksDbErr(ref s) => write!(f, "RocksDb Error: {}", s),
+		&Error::SerErr(ref e) => write!(f, "Serialization Error: {}", e.to_string()),
 	}
+}
 }
 
 impl From<rocksdb::Error> for Error {

--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -15,15 +15,21 @@
 
 use memmap;
 
-use std::fs::{File, OpenOptions, metadata};
-use std::io::{self, Write, BufReader, BufRead};
+use std::cmp;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write, BufReader, BufRead, ErrorKind};
 use std::path::Path;
+use std::io::Read;
 
-use core::core::pmmr::{Summable, Backend, HashSum, VecBackend};
+use core::core::pmmr::{self, Summable, Backend, HashSum, VecBackend};
 use core::ser;
 
 const PMMR_DATA_FILE: &'static str = "pmmr_dat.bin";
 const PMMR_RM_LOG_FILE: &'static str = "pmmr_rm_log.bin";
+const PMMR_PRUNED_FILE: &'static str = "pmmr_pruned.bin";
+
+/// Maximum number of nodes in the remove log before it gets flushed
+pub const RM_LOG_MAX_NODES: usize = 10000;
 
 /// Wrapper for a file that can be read at any position (random read) but for
 /// which writes are append only. Reads are backed by a memory map (mmap(2)),
@@ -77,9 +83,43 @@ impl AppendOnlyFile {
 		(&mmap[offset..(offset + length)]).to_vec()
 	}
 
+	/// Saves a copy of the current file content, skipping data at the provided
+	/// prune indices. The prune Vec must be ordered.
+	fn save_prune(&self, target: String, prune_offs: Vec<u64>, prune_len: u64) -> io::Result<()> {
+		let mut reader = File::open(self.path.clone())?;
+		let mut writer = File::create(target)?;
+
+		// align the buffer on prune_len to avoid misalignments
+		let mut buf = vec![0; (prune_len * 256) as usize];
+		let mut read = 0;
+		let mut prune_pos = 0;
+		loop {
+			// fill our buffer
+			let len = match reader.read(&mut buf) {
+				Ok(0) => return Ok(()),
+				Ok(len) => len,
+				Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+				Err(e) => return Err(e),
+			} as u64;
+
+			// write the buffer, except if we prune offsets in the current span,
+			// in which case we skip 
+			let mut buf_start = 0;
+			while prune_offs[prune_pos] >= read && prune_offs[prune_pos] < read + len {
+				writer.write_all(&buf[buf_start..prune_pos])?;
+				buf_start = (prune_offs[prune_pos] + prune_len) as usize;
+				if prune_offs.len() > prune_pos + 1 {
+					prune_pos += 1;
+				}
+			}
+			writer.write_all(&mut buf[buf_start..(len as usize)])?;
+			read += len;
+		}
+	}
+
 	/// Current size of the file in bytes.
 	fn size(&self) -> io::Result<u64> {
-		metadata(&self.path).map(|md| md.len())
+		fs::metadata(&self.path).map(|md| md.len())
 	}
 }
 
@@ -89,6 +129,7 @@ impl AppendOnlyFile {
 /// log becomes too long, the MMR backend will actually remove chunks from the
 /// MMR data file and truncate the remove log.
 struct RemoveLog {
+	path: String,
 	file: File,
 	// Ordered vector of MMR positions that should get eventually removed.
 	removed: Vec<u64>,
@@ -98,46 +139,20 @@ impl RemoveLog {
 	/// Open the remove log file. The content of the file will be read in memory
 	/// for fast checking.
 	fn open(path: String) -> io::Result<RemoveLog> {
-		let log_path = Path::new(&path);
-		let mut removed = Vec::with_capacity(1000);
-		if log_path.exists() {
-			let mut file = BufReader::with_capacity(8 * 1000, File::open(path.clone())?);
-			loop {
-				// need a block to end mutable borrow before consume
-				let buf_len = {
-					let buf = file.fill_buf()?;
-					if buf.len() == 0 {
-						break;
-					}
-					let elmts_res: Result<Vec<u64>, ser::Error> = ser::deserialize(&mut &buf[..]);
-					match elmts_res {
-						Ok(elmts) => {
-							for elmt in elmts {
-								if let Err(idx) = removed.binary_search(&elmt) {
-									removed.insert(idx, elmt);
-								}
-							}
-						}
-						Err(_) => {
-							return Err(io::Error::new(
-								io::ErrorKind::InvalidData,
-								"Corrupted storage, could not read remove log.",
-							));
-						}
-					}
-					buf.len()
-				};
-				file.consume(buf_len);
-			}
-		}
-
-		let file = OpenOptions::new().append(true).create(true).open(
-			path.clone(),
-		)?;
+		let removed = read_ordered_vec(path.clone())?;
+		let file = OpenOptions::new().append(true).create(true).open(path.clone())?;
 		Ok(RemoveLog {
+			path: path,
 			file: file,
 			removed: removed,
 		})
+	}
+
+	/// Truncate and empties the remove log.
+	fn truncate(&mut self) -> io::Result<()> {
+		self.removed = vec![];
+		self.file = File::create(self.path.clone())?;
+		Ok(())
 	}
 
 	/// Append a set of new positions to the remove log. Both adds those
@@ -181,8 +196,10 @@ pub struct PMMRBackend<T>
 where
 	T: Summable + Clone,
 {
+	data_dir: String,
 	hashsum_file: AppendOnlyFile,
 	remove_log: RemoveLog,
+	pruned_nodes: pmmr::PruneList,
 	// buffers addition of new elements until they're fully written to disk
 	buffer: VecBackend<T>,
 	buffer_index: usize,
@@ -226,14 +243,16 @@ where
 			return None;
 		}
 
-		// TODO check skip list
+		// Third, check if it's in the pruned list or its offset
+		let shift = self.pruned_nodes.get_shift(position);
+		if let None = shift {
+			return None
+		}
 
 		// Must be on disk, doing a read at the correct position
 		let record_len = 32 + T::sum_len();
-		let data = self.hashsum_file.read(
-			(pos as usize) * record_len,
-			record_len,
-		);
+		let file_offset = ((pos - shift.unwrap()) as usize) * record_len;
+		let data = self.hashsum_file.read(file_offset, record_len);
 		match ser::deserialize(&mut &data[..]) {
 			Ok(hashsum) => Some(hashsum),
 			Err(e) => {
@@ -248,7 +267,7 @@ where
 
 	/// Remove HashSums by insertion position
 	fn remove(&mut self, positions: Vec<u64>) -> Result<(), String> {
-		self.buffer.remove(positions.clone());
+		self.buffer.remove(positions.clone()).unwrap();
 		self.remove_log.append(positions).map_err(|e| {
 			format!("Could not write to log storage, disk full? {:?}", e)
 		})
@@ -266,22 +285,127 @@ where
 		let sz = hs_file.size()?;
 		let record_len = 32 + T::sum_len();
 		let rm_log = RemoveLog::open(format!("{}/{}", data_dir, PMMR_RM_LOG_FILE))?;
+		let prune_list = read_ordered_vec(format!("{}/{}", data_dir, PMMR_PRUNED_FILE))?;
 
 		Ok(PMMRBackend {
+			data_dir: data_dir,
 			hashsum_file: hs_file,
 			remove_log: rm_log,
 			buffer: VecBackend::new(),
 			buffer_index: (sz as usize) / record_len,
+			pruned_nodes: pmmr::PruneList{pruned_nodes: prune_list},
 		})
 	}
 
 	/// Syncs all files to disk. A call to sync is required to ensure all the
-	/// data
-	/// has been successfully written to disk.
+	/// data has been successfully written to disk.
 	pub fn sync(&mut self) -> io::Result<()> {
 		self.buffer_index = self.buffer_index + self.buffer.len();
 		self.buffer.clear();
 
 		self.hashsum_file.sync()
 	}
+
+	/// Checks the length of the remove log to see if it should get compacted.
+	/// If so, the remove log is flushed into the pruned list, which itself gets
+	/// saved, and the main hashsum data file is rewritten, cutting the removed
+	/// data.
+	///
+	/// If a max_len strictly greater than 0 is provided, the value will be used
+	/// to decide whether the remove log has reached its maximum length,
+	/// otherwise the RM_LOG_MAX_NODES default value is used.
+	pub fn check_compact(&mut self, max_len: usize) -> io::Result<()> {
+		if !(max_len > 0 && self.remove_log.len() > max_len ||
+			max_len == 0 && self.remove_log.len() > RM_LOG_MAX_NODES) {
+			return Ok(())
+		}
+
+		// 0. validate none of the nodes in the rm log are in the prune list (to
+		// avoid accidental double compaction)
+		for pos in &self.remove_log.removed[..] {
+			if let None = self.pruned_nodes.pruned_pos(*pos) {
+				// TODO we likely can recover from this by directly jumping to 3
+				error!("The remove log contains nodes that are already in the pruned \
+							 list, a previous compaction likely failed.");
+				return Ok(());
+			}
+		}
+
+		// 1. save hashsum file to a compact copy, skipping data that's in the
+		// remove list
+		let tmp_prune_file = format!("{}/{}.prune", self.data_dir, PMMR_DATA_FILE);
+		let record_len = (32 + T::sum_len()) as u64;
+		let to_rm = self.remove_log.removed.iter().map(|pos| {
+			let shift = self.pruned_nodes.get_shift(*pos);
+			(*pos - shift.unwrap()) * record_len
+		}).collect();
+		self.hashsum_file.save_prune(tmp_prune_file.clone(), to_rm, record_len)?;
+
+		// 2. update the prune list and save it in place
+		for rm_pos in &self.remove_log.removed[..] {
+			self.pruned_nodes.add(*rm_pos);
+		}
+		write_vec(format!("{}/{}", self.data_dir, PMMR_PRUNED_FILE), &self.pruned_nodes.pruned_nodes)?;
+
+		// 3. move the compact copy to the hashsum file and re-open it
+		fs::rename(tmp_prune_file.clone(), format!("{}/{}", self.data_dir, PMMR_DATA_FILE))?;
+		self.hashsum_file = AppendOnlyFile::open(format!("{}/{}", self.data_dir, PMMR_DATA_FILE))?;
+		self.hashsum_file.sync()?;
+
+		// 4. truncate the rm log
+		self.remove_log.truncate()?;
+
+		Ok(())
+	}
+}
+
+// Read an ordered vector of scalars from a file.
+fn read_ordered_vec<T>(path: String) -> io::Result<Vec<T>>
+	where T: ser::Readable + cmp::Ord {
+
+	let file_path = Path::new(&path);
+	let mut ovec = Vec::with_capacity(1000);
+	if file_path.exists() {
+		let mut file = BufReader::with_capacity(8 * 1000, File::open(path.clone())?);
+		loop {
+			// need a block to end mutable borrow before consume
+			let buf_len = {
+				let buf = file.fill_buf()?;
+				if buf.len() == 0 {
+					break;
+				}
+				let elmts_res: Result<Vec<T>, ser::Error> = ser::deserialize(&mut &buf[..]);
+				match elmts_res {
+					Ok(elmts) => {
+						for elmt in elmts {
+							if let Err(idx) = ovec.binary_search(&elmt) {
+								ovec.insert(idx, elmt);
+							}
+						}
+					}
+					Err(_) => {
+						return Err(io::Error::new(
+							io::ErrorKind::InvalidData,
+							format!("Corrupted storage, could not read file at {}", path),
+						));
+					}
+				}
+				buf.len()
+			};
+			file.consume(buf_len);
+		}
+	}
+	Ok(ovec)
+}
+
+fn write_vec<T>(path: String, v: &Vec<T>) -> io::Result<()>
+	where T: ser::Writeable {
+	
+	let mut file_path = File::create(&path)?;
+	ser::serialize(&mut file_path, v).map_err(|_| {
+		io::Error::new(
+			io::ErrorKind::InvalidInput,
+			format!("Failed to serialize data when writing to {}", path))
+	})?;
+	Ok(())
 }

--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -1,4 +1,4 @@
-// Copyright 2016 The Grin Developers
+// Copyright 2017 The Grin Developers
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -11,34 +11,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Implementation of the persistent Backend for the prunable MMR sum-tree.
+
 use memmap;
 
-use std::fs::{File, OpenOptions};
+use std::fs::{File, OpenOptions, metadata};
 use std::io::{self, Write, BufReader, BufRead};
-use std::sync::RwLock;
+use std::path::Path;
 
-use core::core::pmmr::{PMMR, Summable, Backend, HashSum};
-use core::ser::{self, Readable, Reader, Writeable, Writer};
+use core::core::pmmr::{Summable, Backend, HashSum, VecBackend};
+use core::ser;
+
+const PMMR_DATA_FILE: &'static str = "pmmr_dat.bin";
+const PMMR_RM_LOG_FILE: &'static str = "pmmr_rm_log.bin";
 
 /// Wrapper for a file that can be read at any position (random read) but for
 /// which writes are append only. Reads are backed by a memory map (mmap(2)),
 /// relying on the operating system for fast access and caching. The memory
 /// map is reallocated to expand it when new writes are flushed.
 struct AppendOnlyFile {
+	path: String,
 	file: File,
-	mmap: memmap::Mmap,
+	mmap: Option<memmap::Mmap>,
 }
 
 impl AppendOnlyFile {
 	/// Open a file (existing or not) as append-only, backed by a mmap.
 	fn open(path: String) -> io::Result<AppendOnlyFile> {
-		let file = OpenOptions::new().append(true).create(true).open(path.clone())?;
-		let mmap = unsafe {
-			memmap::file(&file).protection(memmap::Protection::Read).map()?
-		};
+		let file = OpenOptions::new()
+			.read(true)
+			.append(true)
+			.create(true)
+			.open(path.clone())?;
 		Ok(AppendOnlyFile {
+			path: path,
 			file: file,
-			mmap: mmap,
+			mmap: None,
 		})
 	}
 
@@ -51,16 +59,27 @@ impl AppendOnlyFile {
 	/// written data accessible.
 	fn sync(&mut self) -> io::Result<()> {
 		self.file.sync_data()?;
-		self.mmap = unsafe {
-			memmap::file(&self.file).protection(memmap::Protection::Read).map()?
-		};
+		self.mmap = Some(unsafe {
+			memmap::file(&self.file)
+				.protection(memmap::Protection::Read)
+				.map()?
+		});
 		Ok(())
 	}
 
 	/// Read length bytes of data at offset from the file. Leverages the memory
 	/// map.
 	fn read(&self, offset: usize, length: usize) -> Vec<u8> {
-		(&self.mmap[offset..(offset+length)]).to_vec()
+		if let None = self.mmap {
+			return vec![];
+		}
+		let mmap = self.mmap.as_ref().unwrap();
+		(&mmap[offset..(offset + length)]).to_vec()
+	}
+
+	/// Current size of the file in bytes.
+	fn size(&self) -> io::Result<u64> {
+		metadata(&self.path).map(|md| md.len())
 	}
 }
 
@@ -79,42 +98,50 @@ impl RemoveLog {
 	/// Open the remove log file. The content of the file will be read in memory
 	/// for fast checking.
 	fn open(path: String) -> io::Result<RemoveLog> {
-		let mut file = BufReader::with_capacity(8*1000, File::open(path.clone())?);
+		let log_path = Path::new(&path);
 		let mut removed = Vec::with_capacity(1000);
-		loop {
-			// need a block to end mutable borrow before consume
-			let buf_len = {
-				let buf = file.fill_buf()?;
-				if buf.len() == 0 {
-					break;
-				}
-				let elmts_res: Result<Vec<u64>, ser::Error> = ser::deserialize(&mut &buf[..]);
-				match elmts_res {
-					Ok(elmts) => {
-						for elmt in elmts {
-							if let Err(idx) = removed.binary_search(&elmt) {
-								removed.insert(idx, elmt);
+		if log_path.exists() {
+			let mut file = BufReader::with_capacity(8 * 1000, File::open(path.clone())?);
+			loop {
+				// need a block to end mutable borrow before consume
+				let buf_len = {
+					let buf = file.fill_buf()?;
+					if buf.len() == 0 {
+						break;
+					}
+					let elmts_res: Result<Vec<u64>, ser::Error> = ser::deserialize(&mut &buf[..]);
+					match elmts_res {
+						Ok(elmts) => {
+							for elmt in elmts {
+								if let Err(idx) = removed.binary_search(&elmt) {
+									removed.insert(idx, elmt);
+								}
 							}
 						}
-					},
-					Err(_) => {
-						return Err(io::Error::new(io::ErrorKind::InvalidData,
-																			"Corrupted storage, could not read remove log."));
+						Err(_) => {
+							return Err(io::Error::new(
+								io::ErrorKind::InvalidData,
+								"Corrupted storage, could not read remove log.",
+							));
+						}
 					}
-				}
-				buf.len()
-			};
-			file.consume(buf_len);
+					buf.len()
+				};
+				file.consume(buf_len);
+			}
 		}
-	
-		let file = OpenOptions::new().append(true).create(true).open(path.clone())?;
+
+		let file = OpenOptions::new().append(true).create(true).open(
+			path.clone(),
+		)?;
 		Ok(RemoveLog {
 			file: file,
 			removed: removed,
 		})
 	}
 
-	/// Append a set of new positions to the remove log. Both adds those positions
+	/// Append a set of new positions to the remove log. Both adds those
+	/// positions
 	/// to the ordered in-memory set and to the file.
 	fn append(&mut self, elmts: Vec<u64>) -> io::Result<()> {
 		for elmt in elmts {
@@ -140,19 +167,44 @@ impl RemoveLog {
 	}
 }
 
-pub struct MMRBackend {
-	hashsum_file: RwLock<AppendOnlyFile>,
-	remove_log: RwLock<RemoveLog>,
+/// PMMR persistent backend implementation. Relies on multiple facilities to
+/// handle writing, reading and pruning.
+///
+/// * A main storage file appends HashSum instances as they come. This
+/// AppendOnlyFile is also backed by a mmap for reads.
+/// * An in-memory backend buffers the latest batch of writes to ensure the
+/// PMMR can always read recent values even if they haven't been flushed to
+/// disk yet.
+/// * A remove log tracks the positions that need to be pruned from the
+/// main storage file.
+pub struct PMMRBackend<T>
+where
+	T: Summable + Clone,
+{
+	hashsum_file: AppendOnlyFile,
+	remove_log: RemoveLog,
+	// buffers addition of new elements until they're fully written to disk
+	buffer: VecBackend<T>,
+	buffer_index: usize,
 }
 
-impl<T> Backend<T> for MMRBackend where T: Summable {
+impl<T> Backend<T> for PMMRBackend<T>
+where
+	T: Summable + Clone,
+{
 	/// Append the provided HashSums to the backend storage.
 	#[allow(unused_variables)]
-	fn append(&self, position: u64, data: Vec<HashSum<T>>) -> Result<(), String> {
-		let mut f = self.hashsum_file.write().unwrap();
+	fn append(&mut self, position: u64, data: Vec<HashSum<T>>) -> Result<(), String> {
+		self.buffer.append(
+			position - (self.buffer_index as u64),
+			data.clone(),
+		)?;
 		for hs in data {
-			if let Err(e) = f.append(&ser::ser_vec(&hs).unwrap()[..]) {
-				return Err(format!("Could not write to log storage, disk full? {:?}", e));
+			if let Err(e) = self.hashsum_file.append(&ser::ser_vec(&hs).unwrap()[..]) {
+				return Err(format!(
+					"Could not write to log storage, disk full? {:?}",
+					e
+				));
 			}
 		}
 		Ok(())
@@ -160,55 +212,76 @@ impl<T> Backend<T> for MMRBackend where T: Summable {
 
 	/// Get a HashSum by insertion position
 	fn get(&self, position: u64) -> Option<HashSum<T>> {
-		let log = self.remove_log.read().unwrap();
-		if log.includes(position) {
-			return None
+		// First, check if it's in our temporary write buffer
+		let pos_sz = position as usize;
+		if pos_sz - 1 >= self.buffer_index && pos_sz - 1 < self.buffer_index + self.buffer.len() {
+			return self.buffer.get((pos_sz - self.buffer_index) as u64);
 		}
+
+		// The MMR starts at 1, our backend starts at 0
+		let pos = position - 1;
+
+		// Second, check if this position has been pruned in the remove log
+		if self.remove_log.includes(pos) {
+			return None;
+		}
+
 		// TODO check skip list
+
+		// Must be on disk, doing a read at the correct position
 		let record_len = 32 + T::sum_len();
-		let f = self.hashsum_file.read().unwrap();
-		let data = f.read((position as usize)*record_len, record_len);
+		let data = self.hashsum_file.read(
+			(pos as usize) * record_len,
+			record_len,
+		);
 		match ser::deserialize(&mut &data[..]) {
 			Ok(hashsum) => Some(hashsum),
 			Err(e) => {
-				error!("Corrupted storage, could not read an entry from sum tree store: {:?}", e);
+				error!(
+					"Corrupted storage, could not read an entry from sum tree store: {:?}",
+					e
+				);
 				None
 			}
 		}
 	}
 
 	/// Remove HashSums by insertion position
-	fn remove(&self, positions: Vec<u64>) -> Result<(), String> {
-		let mut log = self.remove_log.write().unwrap();
-		log.append(positions).map_err(|e| {
+	fn remove(&mut self, positions: Vec<u64>) -> Result<(), String> {
+		self.buffer.remove(positions.clone());
+		self.remove_log.append(positions).map_err(|e| {
 			format!("Could not write to log storage, disk full? {:?}", e)
 		})
 	}
 }
- 
-// impl MMRStore<T> where T: Summable {
-// 	pub fn root(&self) -> HashSum<T> {
-// 	}
-// 
-// 	pub fn view(&self) -> View<T> {
-// 	}
-// }
-// 
-// pub struct View<T: Summable + Writeable> {
-//   view_tree: MMR<T>
-// }
-// 
-// impl <T> View<T> where T: Summable {
-// 
-// 	pub fn root(&self) -> Option<(Hash, T::Sum)> {
-//     None
-//   }
-// 
-// 	pub fn push(&mut self, elmt: T) -> u64 {
-// 	}
-// 
-// 	pub fn prune(&self, position: u64) {
-// 	}
-// 
-//   pub fn commit(self) {}
-// }
+
+impl<T> PMMRBackend<T>
+where
+	T: Summable + Clone,
+{
+	/// Instantiates a new PMMR backend that will use the provided directly to
+	/// store its files.
+	pub fn new(data_dir: String) -> io::Result<PMMRBackend<T>> {
+		let hs_file = AppendOnlyFile::open(format!("{}/{}", data_dir, PMMR_DATA_FILE))?;
+		let sz = hs_file.size()?;
+		let record_len = 32 + T::sum_len();
+		let rm_log = RemoveLog::open(format!("{}/{}", data_dir, PMMR_RM_LOG_FILE))?;
+
+		Ok(PMMRBackend {
+			hashsum_file: hs_file,
+			remove_log: rm_log,
+			buffer: VecBackend::new(),
+			buffer_index: (sz as usize) / record_len,
+		})
+	}
+
+	/// Syncs all files to disk. A call to sync is required to ensure all the
+	/// data
+	/// has been successfully written to disk.
+	pub fn sync(&mut self) -> io::Result<()> {
+		self.buffer_index = self.buffer_index + self.buffer.len();
+		self.buffer.clear();
+
+		self.hashsum_file.sync()
+	}
+}

--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -49,11 +49,16 @@ impl AppendOnlyFile {
 			.append(true)
 			.create(true)
 			.open(path.clone())?;
-		Ok(AppendOnlyFile {
-			path: path,
+		let mut aof = AppendOnlyFile {
+			path: path.clone(),
 			file: file,
 			mmap: None,
-		})
+		};
+		let file_path = Path::new(&path);
+		if file_path.exists() {
+			aof.sync();
+		}
+		Ok(aof)
 	}
 
 	/// Append data to the file.
@@ -360,7 +365,7 @@ where
 		self.hashsum_file.sync()?;
 
 		// 4. truncate the rm log
-		//self.remove_log.truncate()?;
+		self.remove_log.truncate()?;
 
 		Ok(())
 	}

--- a/store/src/sumtree.rs
+++ b/store/src/sumtree.rs
@@ -1,0 +1,214 @@
+// Copyright 2016 The Grin Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use memmap;
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write, BufReader, BufRead};
+use std::sync::RwLock;
+
+use core::core::pmmr::{PMMR, Summable, Backend, HashSum};
+use core::ser::{self, Readable, Reader, Writeable, Writer};
+
+/// Wrapper for a file that can be read at any position (random read) but for
+/// which writes are append only. Reads are backed by a memory map (mmap(2)),
+/// relying on the operating system for fast access and caching. The memory
+/// map is reallocated to expand it when new writes are flushed.
+struct AppendOnlyFile {
+	file: File,
+	mmap: memmap::Mmap,
+}
+
+impl AppendOnlyFile {
+	/// Open a file (existing or not) as append-only, backed by a mmap.
+	fn open(path: String) -> io::Result<AppendOnlyFile> {
+		let file = OpenOptions::new().append(true).create(true).open(path.clone())?;
+		let mmap = unsafe {
+			memmap::file(&file).protection(memmap::Protection::Read).map()?
+		};
+		Ok(AppendOnlyFile {
+			file: file,
+			mmap: mmap,
+		})
+	}
+
+	/// Append data to the file.
+	fn append(&mut self, buf: &[u8]) -> io::Result<()> {
+		self.file.write_all(buf)
+	}
+
+	/// Syncs all writes (fsync), reallocating the memory map to make the newly
+	/// written data accessible.
+	fn sync(&mut self) -> io::Result<()> {
+		self.file.sync_data()?;
+		self.mmap = unsafe {
+			memmap::file(&self.file).protection(memmap::Protection::Read).map()?
+		};
+		Ok(())
+	}
+
+	/// Read length bytes of data at offset from the file. Leverages the memory
+	/// map.
+	fn read(&self, offset: usize, length: usize) -> Vec<u8> {
+		(&self.mmap[offset..(offset+length)]).to_vec()
+	}
+}
+
+/// Log file fully cached in memory containing all positions that should be
+/// eventually removed from the MMR append-only data file. Allows quick
+/// checking of whether a piece of data has been marked for deletion. When the
+/// log becomes too long, the MMR backend will actually remove chunks from the
+/// MMR data file and truncate the remove log.
+struct RemoveLog {
+	file: File,
+	// Ordered vector of MMR positions that should get eventually removed.
+	removed: Vec<u64>,
+}
+
+impl RemoveLog {
+	/// Open the remove log file. The content of the file will be read in memory
+	/// for fast checking.
+	fn open(path: String) -> io::Result<RemoveLog> {
+		let mut file = BufReader::with_capacity(8*1000, File::open(path.clone())?);
+		let mut removed = Vec::with_capacity(1000);
+		loop {
+			// need a block to end mutable borrow before consume
+			let buf_len = {
+				let buf = file.fill_buf()?;
+				if buf.len() == 0 {
+					break;
+				}
+				let elmts_res: Result<Vec<u64>, ser::Error> = ser::deserialize(&mut &buf[..]);
+				match elmts_res {
+					Ok(elmts) => {
+						for elmt in elmts {
+							if let Err(idx) = removed.binary_search(&elmt) {
+								removed.insert(idx, elmt);
+							}
+						}
+					},
+					Err(_) => {
+						return Err(io::Error::new(io::ErrorKind::InvalidData,
+																			"Corrupted storage, could not read remove log."));
+					}
+				}
+				buf.len()
+			};
+			file.consume(buf_len);
+		}
+	
+		let file = OpenOptions::new().append(true).create(true).open(path.clone())?;
+		Ok(RemoveLog {
+			file: file,
+			removed: removed,
+		})
+	}
+
+	/// Append a set of new positions to the remove log. Both adds those positions
+	/// to the ordered in-memory set and to the file.
+	fn append(&mut self, elmts: Vec<u64>) -> io::Result<()> {
+		for elmt in elmts {
+			match self.removed.binary_search(&elmt) {
+				Ok(_) => continue,
+				Err(idx) => {
+					self.file.write_all(&ser::ser_vec(&elmt).unwrap()[..])?;
+					self.removed.insert(idx, elmt);
+				}
+			}
+		}
+		self.file.sync_data()
+	}
+
+	/// Whether the remove log currently includes the provided position.
+	fn includes(&self, elmt: u64) -> bool {
+		self.removed.binary_search(&elmt).is_ok()
+	}
+
+	/// Number of positions stored in the remove log.
+	fn len(&self) -> usize {
+		self.removed.len()
+	}
+}
+
+pub struct MMRBackend {
+	hashsum_file: RwLock<AppendOnlyFile>,
+	remove_log: RwLock<RemoveLog>,
+}
+
+impl<T> Backend<T> for MMRBackend where T: Summable {
+	/// Append the provided HashSums to the backend storage.
+	#[allow(unused_variables)]
+	fn append(&self, position: u64, data: Vec<HashSum<T>>) -> Result<(), String> {
+		let mut f = self.hashsum_file.write().unwrap();
+		for hs in data {
+			if let Err(e) = f.append(&ser::ser_vec(&hs).unwrap()[..]) {
+				return Err(format!("Could not write to log storage, disk full? {:?}", e));
+			}
+		}
+		Ok(())
+	}
+
+	/// Get a HashSum by insertion position
+	fn get(&self, position: u64) -> Option<HashSum<T>> {
+		let log = self.remove_log.read().unwrap();
+		if log.includes(position) {
+			return None
+		}
+		// TODO check skip list
+		let record_len = 32 + T::sum_len();
+		let f = self.hashsum_file.read().unwrap();
+		let data = f.read((position as usize)*record_len, record_len);
+		match ser::deserialize(&mut &data[..]) {
+			Ok(hashsum) => Some(hashsum),
+			Err(e) => {
+				error!("Corrupted storage, could not read an entry from sum tree store: {:?}", e);
+				None
+			}
+		}
+	}
+
+	/// Remove HashSums by insertion position
+	fn remove(&self, positions: Vec<u64>) -> Result<(), String> {
+		let mut log = self.remove_log.write().unwrap();
+		log.append(positions).map_err(|e| {
+			format!("Could not write to log storage, disk full? {:?}", e)
+		})
+	}
+}
+ 
+// impl MMRStore<T> where T: Summable {
+// 	pub fn root(&self) -> HashSum<T> {
+// 	}
+// 
+// 	pub fn view(&self) -> View<T> {
+// 	}
+// }
+// 
+// pub struct View<T: Summable + Writeable> {
+//   view_tree: MMR<T>
+// }
+// 
+// impl <T> View<T> where T: Summable {
+// 
+// 	pub fn root(&self) -> Option<(Hash, T::Sum)> {
+//     None
+//   }
+// 
+// 	pub fn push(&mut self, elmt: T) -> u64 {
+// 	}
+// 
+// 	pub fn prune(&self, position: u64) {
+// 	}
+// 
+//   pub fn commit(self) {}
+// }

--- a/store/tests/sumtree.rs
+++ b/store/tests/sumtree.rs
@@ -52,7 +52,7 @@ fn sumtree_append() {
 	let _ = env_logger::init();
 
 	let t = time::get_time();
-	let data_dir = format!("./{}.{}", t.sec, t.nsec);
+	let data_dir = format!("./target/{}.{}", t.sec, t.nsec);
 	fs::create_dir_all(data_dir.clone()).unwrap();
 
 	let elems = vec![
@@ -119,7 +119,7 @@ fn sumtree_prune_compact() {
 	let _ = env_logger::init();
 
 	let t = time::get_time();
-	let data_dir = format!("./{}.{}", t.sec, t.nsec);
+	let data_dir = format!("./target/{}.{}", t.sec, t.nsec);
 	fs::create_dir_all(data_dir.clone()).unwrap();
 
 	let elems = vec![

--- a/store/tests/sumtree.rs
+++ b/store/tests/sumtree.rs
@@ -66,6 +66,7 @@ fn sumtree_append() {
 		TestElem([1, 0, 0, 0]),
 	];
 
+	// adding first set of 4 elements and sync
 	let mut mmr_size: u64;
 	let mut backend = store::sumtree::PMMRBackend::new(data_dir).unwrap();
 	{
@@ -77,6 +78,7 @@ fn sumtree_append() {
 	}
 	backend.sync().unwrap();
 
+	// adding the rest and sync again
 	{
 		let mut pmmr = PMMR::at(&mut backend, mmr_size);
 		for elem in &elems[4..elems.len()] {
@@ -86,6 +88,7 @@ fn sumtree_append() {
 	}
 	backend.sync().unwrap();
 
+	// check the resulting backend store and the computation of the root
 	let hash = Hashed::hash(&elems[0].clone());
 	let sum = elems[0].sum();
 	let node_hash = (1 as u64, &sum, hash).hash();

--- a/store/tests/sumtree.rs
+++ b/store/tests/sumtree.rs
@@ -1,0 +1,111 @@
+// Copyright 2017 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate env_logger;
+extern crate grin_core as core;
+extern crate grin_store as store;
+extern crate time;
+
+use std::fs;
+
+use core::ser::*;
+use core::core::pmmr::{PMMR, Summable, HashSum, Backend};
+use core::core::hash::Hashed;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct TestElem([u32; 4]);
+impl Summable for TestElem {
+	type Sum = u64;
+	fn sum(&self) -> u64 {
+		// sums are not allowed to overflow, so we use this simple
+		// non-injective "sum" function that will still be homomorphic
+		self.0[0] as u64 * 0x1000 + self.0[1] as u64 * 0x100 + self.0[2] as u64 * 0x10 +
+			self.0[3] as u64
+	}
+	fn sum_len() -> usize {
+		8
+	}
+}
+
+impl Writeable for TestElem {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		try!(writer.write_u32(self.0[0]));
+		try!(writer.write_u32(self.0[1]));
+		try!(writer.write_u32(self.0[2]));
+		writer.write_u32(self.0[3])
+	}
+}
+
+#[test]
+fn sumtree_append() {
+	let _ = env_logger::init();
+
+	let data_dir = format!("./{}", time::get_time().sec);
+	fs::create_dir_all(data_dir.clone()).unwrap();
+
+	let elems = vec![
+		TestElem([0, 0, 0, 1]),
+		TestElem([0, 0, 0, 2]),
+		TestElem([0, 0, 0, 3]),
+		TestElem([0, 0, 0, 4]),
+		TestElem([0, 0, 0, 5]),
+		TestElem([0, 0, 0, 6]),
+		TestElem([0, 0, 0, 7]),
+		TestElem([0, 0, 0, 8]),
+		TestElem([1, 0, 0, 0]),
+	];
+
+	let mut mmr_size: u64;
+	let mut backend = store::sumtree::PMMRBackend::new(data_dir).unwrap();
+	{
+		let mut pmmr = PMMR::new(&mut backend);
+		for elem in &elems[0..4] {
+			pmmr.push(elem.clone());
+		}
+		mmr_size = pmmr.unpruned_size();
+	}
+	backend.sync().unwrap();
+
+	{
+		let mut pmmr = PMMR::at(&mut backend, mmr_size);
+		for elem in &elems[4..elems.len()] {
+			pmmr.push(elem.clone());
+		}
+		mmr_size = pmmr.unpruned_size();
+	}
+	backend.sync().unwrap();
+
+	let hash = Hashed::hash(&elems[0].clone());
+	let sum = elems[0].sum();
+	let node_hash = (1 as u64, &sum, hash).hash();
+	assert_eq!(
+		backend.get(1),
+		Some(HashSum {
+			hash: node_hash,
+			sum: sum,
+		})
+	);
+
+	let sum2 = HashSum::from_summable(1, &elems[0]) + HashSum::from_summable(2, &elems[1]);
+	let sum4 = sum2 + (HashSum::from_summable(4, &elems[2]) + HashSum::from_summable(5, &elems[3]));
+	let sum8 = sum4 +
+		((HashSum::from_summable(8, &elems[4]) + HashSum::from_summable(9, &elems[5])) +
+			 (HashSum::from_summable(11, &elems[6]) + HashSum::from_summable(12, &elems[7])));
+	let sum9 = sum8 + HashSum::from_summable(16, &elems[8]);
+
+	{
+		let pmmr = PMMR::at(&mut backend, mmr_size);
+		assert_eq!(pmmr.root(), sum9);
+	}
+}


### PR DESCRIPTION
Full storage of the prunable MMR sum-tree, including the main file store containing sums and hashes, the remove log and a prune list structure to keep track of what has been pruned already. 