### PR TITLE
added basic tests around range_proof

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -458,7 +458,8 @@ impl Block {
 		let sig = try!(secp.sign(&msg, &skey));
 		let commit = secp.commit(REWARD, skey).unwrap();
 		//let switch_commit = secp.switch_commit(skey).unwrap();
-		let rproof = secp.range_proof(0, REWARD, skey, commit);
+		let nonce = secp.nonce();
+		let rproof = secp.range_proof(0, REWARD, skey, commit, nonce);
 
 		let output = Output {
 			features: COINBASE_OUTPUT,

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -110,7 +110,8 @@ pub fn input_rand(value: u64) -> Box<Append> {
 pub fn output(value: u64, blinding: SecretKey) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let commit = build.secp.commit(value, blinding).unwrap();
-		let rproof = build.secp.range_proof(0, value, blinding, commit);
+		let nonce = build.secp.nonce();
+		let rproof = build.secp.range_proof(0, value, blinding, commit, nonce);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,
@@ -127,7 +128,8 @@ pub fn output_rand(value: u64) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let blinding = SecretKey::new(&build.secp, &mut build.rng);
 		let commit = build.secp.commit(value, blinding).unwrap();
-		let rproof = build.secp.range_proof(0, value, blinding, commit);
+		let nonce = build.secp.nonce();
+		let rproof = build.secp.range_proof(0, value, blinding, commit, nonce);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -233,7 +233,7 @@ mod tests {
         let outputs = vec![core::transaction::Output{
                 features: core::transaction::DEFAULT_OUTPUT,
                 commit: output_commit,
-                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit)}];
+                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit, ec.nonce())}];
         let test_transaction = core::transaction::Transaction::new(inputs,
             outputs, 5);
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -892,7 +892,7 @@ mod tests {
         transaction::Output{
             features: transaction::DEFAULT_OUTPUT,
             commit: output_commitment,
-            proof: ec.range_proof(0, value, output_key, output_commitment)}
+            proof: ec.range_proof(0, value, output_key, output_commitment, ec.nonce())}
     }
 
     /// Makes a SecretKey from a single u64


### PR DESCRIPTION
* add basic unit tests around `range_proof` and `verify_range_proof`
* pass `nonce` in as param to `range_proof` - needed for `rewind_range_proof`
