### PR TITLE
WIP - support message in range proof (and recover value via rewind_range_proof)

### DIFF
--- a/core/benches/output_value_recovery.rs
+++ b/core/benches/output_value_recovery.rs
@@ -1,0 +1,70 @@
+// Copyright 2017 The Grin Developers
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+
+extern crate test;
+extern crate rand;
+extern crate grin_core as core;
+extern crate secp256k1zkp as secp;
+
+use core::core::{DEFAULT_OUTPUT, Output};
+use secp::Secp256k1;
+use secp::key::SecretKey;
+use secp::pedersen::ProofMessage;
+
+use test::Bencher;
+use rand::os::OsRng;
+
+#[bench]
+fn bench_successful_recovery(b: &mut Bencher) {
+    let secp = Secp256k1::with_caps(secp::ContextFlag::Commit);
+
+    let message = ProofMessage::empty();
+
+    let key = SecretKey::new(&secp, &mut OsRng::new().unwrap());
+
+    let commit = secp.commit(1, key).unwrap();
+    let range_proof = secp.range_proof(0, 1, key, commit, &message);
+    let output = Output {
+		features: DEFAULT_OUTPUT,
+		commit: commit,
+		proof: range_proof,
+	};
+
+    b.iter(|| {
+         output.recover_value(&secp, key);            
+    })
+}
+
+#[bench]
+fn bench_unsuccessful_recovery(b: &mut Bencher) {
+    let secp = Secp256k1::with_caps(secp::ContextFlag::Commit);
+
+    let message = ProofMessage::empty();
+
+    let key = SecretKey::new(&secp, &mut OsRng::new().unwrap());
+
+    let commit = secp.commit(1, key).unwrap();
+    let range_proof = secp.range_proof(0, 1, key, commit, &message);
+    let output = Output {
+		features: DEFAULT_OUTPUT,
+		commit: commit,
+		proof: range_proof,
+	};
+
+    let bad_key = SecretKey::new(&secp, &mut OsRng::new().unwrap());
+    b.iter(|| {
+        output.recover_value(&secp, bad_key);
+    })
+}

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -466,12 +466,11 @@ impl Block {
 		let msg = try!(secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE]));
 		let sig = try!(secp.sign(&msg, &skey));
 
-        let commit = secp.commit(REWARD, skey).unwrap();
+		let commit = secp.commit(REWARD, skey).unwrap();
 		//let switch_commit = secp.switch_commit(skey).unwrap();
 
-        let message = secp::pedersen::ProofMessage::empty();
-		let nonce = secp.nonce();
-		let rproof = secp.range_proof(0, REWARD, skey, commit, &message, nonce);
+		let message = secp::pedersen::ProofMessage::empty();
+		let rproof = secp.range_proof(0, REWARD, skey, commit, &message);
 
 		let output = Output {
 			features: COINBASE_OUTPUT,

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -465,10 +465,13 @@ impl Block {
 	                     -> Result<(Output, TxKernel), secp::Error> {
 		let msg = try!(secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE]));
 		let sig = try!(secp.sign(&msg, &skey));
-		let commit = secp.commit(REWARD, skey).unwrap();
+
+        let commit = secp.commit(REWARD, skey).unwrap();
 		//let switch_commit = secp.switch_commit(skey).unwrap();
+
+        let message = secp::pedersen::ProofMessage::empty();
 		let nonce = secp.nonce();
-		let rproof = secp.range_proof(0, REWARD, skey, commit, nonce);
+		let rproof = secp.range_proof(0, REWARD, skey, commit, &message, nonce);
 
 		let output = Output {
 			features: COINBASE_OUTPUT,

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -28,6 +28,7 @@
 use byteorder::{ByteOrder, BigEndian};
 use secp::{self, Secp256k1};
 use secp::key::SecretKey;
+use secp::pedersen::ProofMessage;
 use rand::os::OsRng;
 
 use core::{Transaction, Input, Output, DEFAULT_OUTPUT};
@@ -110,8 +111,9 @@ pub fn input_rand(value: u64) -> Box<Append> {
 pub fn output(value: u64, blinding: SecretKey) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let commit = build.secp.commit(value, blinding).unwrap();
+		let message = ProofMessage::empty();
 		let nonce = build.secp.nonce();
-		let rproof = build.secp.range_proof(0, value, blinding, commit, nonce);
+		let rproof = build.secp.range_proof(0, value, blinding, commit, &message, nonce);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,
@@ -128,8 +130,9 @@ pub fn output_rand(value: u64) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let blinding = SecretKey::new(&build.secp, &mut build.rng);
 		let commit = build.secp.commit(value, blinding).unwrap();
+		let message = ProofMessage::empty();
 		let nonce = build.secp.nonce();
-		let rproof = build.secp.range_proof(0, value, blinding, commit, nonce);
+		let rproof = build.secp.range_proof(0, value, blinding, commit, &message, nonce);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -112,8 +112,7 @@ pub fn output(value: u64, blinding: SecretKey) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let commit = build.secp.commit(value, blinding).unwrap();
 		let message = ProofMessage::empty();
-		let nonce = build.secp.nonce();
-		let rproof = build.secp.range_proof(0, value, blinding, commit, &message, nonce);
+		let rproof = build.secp.range_proof(0, value, blinding, commit, &message);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,
@@ -131,8 +130,7 @@ pub fn output_rand(value: u64) -> Box<Append> {
 		let blinding = SecretKey::new(&build.secp, &mut build.rng);
 		let commit = build.secp.commit(value, blinding).unwrap();
 		let message = ProofMessage::empty();
-		let nonce = build.secp.nonce();
-		let rproof = build.secp.range_proof(0, value, blinding, commit, &message, nonce);
+		let rproof = build.secp.range_proof(0, value, blinding, commit, &message);
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,
 			commit: commit,

--- a/core/src/core/transaction.rs
+++ b/core/src/core/transaction.rs
@@ -371,13 +371,12 @@ mod test {
     use secp::pedersen::ProofMessage;
     use rand::os::OsRng;
 
-
     #[test]
     fn test_output_value_recovery() {
         let secp = Secp256k1::with_caps(secp::ContextFlag::Commit);
         let mut rng = OsRng::new().unwrap();
 
-        let value = 103;
+        let value = 1003;
 
         let blinding = SecretKey::new(&secp, &mut rng);
 		let commit = secp.commit(value, blinding).unwrap();

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -233,7 +233,7 @@ mod tests {
         let outputs = vec![core::transaction::Output{
                 features: core::transaction::DEFAULT_OUTPUT,
                 commit: output_commit,
-                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit, ec.nonce())}];
+                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit, ec.nonce().as_ref())}];
         let test_transaction = core::transaction::Transaction::new(inputs,
             outputs, 5);
 

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -221,19 +221,20 @@ pub fn transaction_identifier(tx: &core::transaction::Transaction) -> core::hash
 mod tests {
     use super::*;
     use secp::{Secp256k1, ContextFlag};
+    use secp::pedersen::ProofMessage;
     use secp::key;
 
     #[test]
     fn test_add_entry() {
         let ec = Secp256k1::with_caps(ContextFlag::Commit);
-
+        let message = ProofMessage::empty();
         let output_commit = ec.commit_value(70).unwrap();
         let inputs = vec![core::transaction::Input(ec.commit_value(50).unwrap()),
                 core::transaction::Input(ec.commit_value(25).unwrap())];
         let outputs = vec![core::transaction::Output{
                 features: core::transaction::DEFAULT_OUTPUT,
                 commit: output_commit,
-                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit, ec.nonce().as_ref())}];
+                proof: ec.range_proof(0, 100, key::ZERO_KEY, output_commit, &message)}];
         let test_transaction = core::transaction::Transaction::new(inputs,
             outputs, 5);
 

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -970,10 +970,11 @@ mod tests {
         let ec = Secp256k1::with_caps(ContextFlag::Commit);
         let output_key = test_key(value);
         let output_commitment = ec.commit(value, output_key).unwrap();
+        let message = ProofMessage::empty();
         transaction::Output{
             features: transaction::COINBASE_OUTPUT,
             commit: output_commitment,
-            proof: ec.range_proof(0, value, output_key, output_commitment)}
+            proof: ec.range_proof(0, value, output_key, output_commitment, &message)}
     }
 
     /// Makes a SecretKey from a single u64

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -483,6 +483,7 @@ mod tests {
     use types::*;
     use secp::{Secp256k1, ContextFlag, constants};
     use secp::key;
+    use secp::pedersen::ProofMessage;
     use core::core::build;
     use blockchain::{DummyChain, DummyChainImpl, DummyUtxoSet};
     use std::sync::{Arc, RwLock};
@@ -956,10 +957,12 @@ mod tests {
         let ec = Secp256k1::with_caps(ContextFlag::Commit);
         let output_key = test_key(value);
         let output_commitment = ec.commit(value, output_key).unwrap();
+        let message = ProofMessage::empty();
         transaction::Output{
             features: transaction::DEFAULT_OUTPUT,
             commit: output_commitment,
-            proof: ec.range_proof(0, value, output_key, output_commitment, ec.nonce())}
+            proof: ec.range_proof(0, value, output_key, output_commitment, &message)
+        }
     }
 
     /// Deterministically generate a coinbase output defined by our test scheme

--- a/secp256k1zkp/depend/secp256k1-zkp/src/modules/rangeproof/main_impl.h
+++ b/secp256k1zkp/depend/secp256k1-zkp/src/modules/rangeproof/main_impl.h
@@ -226,19 +226,21 @@ int secp256k1_rangeproof_verify(const secp256k1_context* ctx, uint64_t *min_valu
 }
 
 int secp256k1_rangeproof_sign(const secp256k1_context* ctx, unsigned char *proof, int *plen, uint64_t min_value,
- const unsigned char *commit, const unsigned char *blind, const unsigned char *nonce, int exp, int min_bits, uint64_t value){
+ const unsigned char *commit, const unsigned char *blind, const unsigned char *nonce, int exp, int min_bits, uint64_t value,
+ const unsigned char *message, size_t msg_len){
     ARG_CHECK(ctx != NULL);
     ARG_CHECK(proof != NULL);
     ARG_CHECK(plen != NULL);
     ARG_CHECK(commit != NULL);
     ARG_CHECK(blind != NULL);
     ARG_CHECK(nonce != NULL);
+    ARG_CHECK(message != NULL || msg_len == 0);
     ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     ARG_CHECK(secp256k1_pedersen_context_is_built(&ctx->pedersen_ctx));
     ARG_CHECK(secp256k1_rangeproof_context_is_built(&ctx->rangeproof_ctx));
     return secp256k1_rangeproof_sign_impl(&ctx->ecmult_ctx, &ctx->ecmult_gen_ctx, &ctx->pedersen_ctx, &ctx->rangeproof_ctx,
-     proof, plen, min_value, commit, blind, nonce, exp, min_bits, value);
+     proof, plen, min_value, commit, blind, nonce, exp, min_bits, value, message, msg_len);
 }
 
 #endif

--- a/secp256k1zkp/src/constants.rs
+++ b/secp256k1zkp/src/constants.rs
@@ -51,7 +51,9 @@ pub const PEDERSEN_COMMITMENT_SIZE: usize = 33;
 pub const MAX_PROOF_SIZE: usize = 5134;
 
 /// The maximum size of a message embedded in a range proof
-pub const PROOF_MSG_SIZE: usize = 4096;
+// TODO - why does this hang if we set it as 4096???
+// pub const PROOF_MSG_SIZE: usize = 4096;
+pub const PROOF_MSG_SIZE: usize = 2048;
 
 /// The order of the secp256k1 curve
 pub const CURVE_ORDER: [u8; 32] = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,

--- a/secp256k1zkp/src/ffi.rs
+++ b/secp256k1zkp/src/ffi.rs
@@ -293,7 +293,7 @@ extern "C" {
 	                      scalar: *const c_uchar)
 	                      -> c_int;
 
-	// Generates a switch commitment: *commit = blind * J 
+	// Generates a switch commitment: *commit = blind * J
 	// The commitment is 33 bytes, the blinding factor is 32 bytes.
 	pub fn secp256k1_switch_commit(ctx: *const Context,
 	                                 commit: *mut c_uchar,
@@ -377,6 +377,8 @@ extern "C" {
 	                                 nonce: *const c_uchar,
 	                                 exp: c_int,
 	                                 min_bits: c_int,
-	                                 value: uint64_t)
+	                                 value: uint64_t,
+                                     message: *const c_uchar,
+                                     msg_len: c_int)
 	                                 -> c_int;
 }

--- a/secp256k1zkp/src/pedersen.rs
+++ b/secp256k1zkp/src/pedersen.rs
@@ -27,7 +27,6 @@ use constants;
 use ffi;
 use key;
 use key::SecretKey;
-use rand::{Rng, OsRng};
 use serde::{ser, de};
 
 /// A Pedersen commitment
@@ -162,15 +161,11 @@ impl RangeProof {
 	}
 }
 
-pub struct ProofMessage {
-    pub msg: Vec<u8>,
-}
+pub struct ProofMessage(Vec<u8>);
 
 impl ProofMessage {
     pub fn empty() -> ProofMessage {
-        ProofMessage {
-            msg: vec![],
-        }
+        ProofMessage(vec![])
     }
 
     pub fn from_bytes(array: &[u8]) -> ProofMessage {
@@ -178,21 +173,29 @@ impl ProofMessage {
         for &value in array {
             msg.push(value);
         }
-        ProofMessage { msg, }
+        ProofMessage(msg)
     }
 
-    pub fn msg_len(&self) -> i32 {
-        self.msg.len() as i32
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.iter().as_slice()
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
+    pub fn len(&self) -> i32 {
+        self.0.len() as i32
     }
 
     pub fn truncate(&mut self, len: usize) {
-        self.msg.truncate(len)
+        self.0.truncate(len)
     }
 }
 
 impl ::std::cmp::PartialEq for ProofMessage {
 	fn eq(&self, other: &ProofMessage) -> bool {
-		self.msg[..] == other.msg[..]
+		self.0[..] == other.0[..]
 	}
 }
 impl ::std::cmp::Eq for ProofMessage {}
@@ -200,7 +203,7 @@ impl ::std::cmp::Eq for ProofMessage {}
 impl ::std::fmt::Debug for ProofMessage {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
 		try!(write!(f, "{}(", stringify!(ProofMessage)));
-		for i in self.msg.iter().cloned() {
+		for i in self.0.iter().cloned() {
 			try!(write!(f, "{:02x}", i));
 		}
 		write!(f, ")")
@@ -353,15 +356,6 @@ impl Secp256k1 {
 		SecretKey::from_slice(self, &ret)
 	}
 
-    /// Convenience function for generating a random nonce for a range proof.
-    /// We will need the nonce later if we want to rewind the range proof.
-    pub fn nonce(&self) -> [u8; 32] {
-        let mut rng = OsRng::new().unwrap();
-        let mut nonce = [0u8; 32];
-        rng.fill_bytes(&mut nonce);
-        nonce
-    }
-
 	/// Produces a range proof for the provided value, using min and max
 	/// bounds, relying
 	/// on the blinding factor and commitment.
@@ -371,12 +365,15 @@ impl Secp256k1 {
                         value: u64,
                         blind: SecretKey,
                         commit: Commitment,
-                        message: &ProofMessage,
-                        nonce: [u8; 32])
+                        message: &ProofMessage)
                         -> RangeProof {
 		let mut retried = false;
 		let mut proof = [0; constants::MAX_PROOF_SIZE];
 		let mut plen = constants::MAX_PROOF_SIZE as i32;
+
+        // here we use a "known key" as the nonce, specifically the blinding factor
+        // of the commitment for which we are generating the range proof
+        let nonce = blind.clone();
 
 		loop {
 			let err = unsafe {
@@ -392,8 +389,8 @@ impl Secp256k1 {
 				                               0,
 				                               64,
 				                               value,
-                                               message.msg.as_ptr(),
-                                               message.msg_len())
+                                               message.as_ptr(),
+                                               message.len())
 
 			};
 			if retried {
@@ -440,7 +437,7 @@ impl Secp256k1 {
 	pub fn rewind_range_proof(&self,
 	                          commit: Commitment,
 	                          proof: RangeProof,
-	                          nonce: [u8; 32])
+	                          nonce: SecretKey)
 	                          -> ProofInfo {
 		let mut value: u64 = 0;
 		let mut blind: [u8; 32] = unsafe { mem::uninitialized() };
@@ -461,6 +458,10 @@ impl Secp256k1 {
 			                                 proof.proof.as_ptr(),
 			                                 proof.plen as i32) == 1
 		};
+
+        // the recovered blinding factor must be equal to the nonce here
+        // assert!(blinding == nonce);
+
 		ProofInfo {
 			success: success,
 			value: value,
@@ -674,8 +675,7 @@ mod tests {
 
         let commit = secp.commit(7, blinding).unwrap();
         let message = ProofMessage::empty();
-        let nonce = secp.nonce();
-        let range_proof = secp.range_proof(0, 7, blinding, commit, &message, nonce);
+        let range_proof = secp.range_proof(0, 7, blinding, commit, &message);
         secp.verify_range_proof(commit, range_proof).unwrap();
 
         let proof_info = secp.range_proof_info(range_proof);
@@ -684,27 +684,47 @@ mod tests {
         // check we get no information back for the value here
         assert_eq!(proof_info.value, 0);
 
-        let proof_info = secp.rewind_range_proof(commit, range_proof, nonce);
+        let proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
         assert!(proof_info.success);
         assert_eq!(proof_info.min, 0);
         assert_eq!(proof_info.value, 7);
 
         // check we cannot rewind a range proof without the original nonce
-        let bad_nonce = secp.nonce();
-        let bad_info = secp.rewind_range_proof(commit, range_proof, bad_nonce);
+        let bad_key = SecretKey::new(&secp, &mut OsRng::new().unwrap());
+        let bad_info = secp.rewind_range_proof(commit, range_proof, bad_key);
         assert_eq!(bad_info.success, false);
         assert_eq!(bad_info.value, 0);
 
         // check we can construct and verify a range proof on value 0
         let commit = secp.commit(0, blinding).unwrap();
         let message = ProofMessage::empty();
-        let nonce = secp.nonce();
-        let range_proof = secp.range_proof(0, 0, blinding, commit, &message, nonce);
+        let range_proof = secp.range_proof(0, 0, blinding, commit, &message);
         secp.verify_range_proof(commit, range_proof).unwrap();
-        let proof_info = secp.rewind_range_proof(commit, range_proof, nonce);
+        let proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
         assert!(proof_info.success);
         assert_eq!(proof_info.min, 0);
         assert_eq!(proof_info.value, 0);
+
+        // non-zero min on valid range proof
+        let commit = secp.commit(1, blinding).unwrap();
+        let message = ProofMessage::empty();
+        let range_proof = secp.range_proof(1, 1, blinding, commit, &message);
+        secp.verify_range_proof(commit, range_proof).unwrap();
+        let proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
+        assert!(proof_info.success);
+        assert_eq!(proof_info.min, 1);
+        assert_eq!(proof_info.value, 1);
+
+        // this actually hangs and does not return - do we need to handle this?
+        // non-zero min with invalid range proof
+        // let commit = secp.commit(0, blinding).unwrap();
+        // let message = ProofMessage::empty();
+        // let range_proof = secp.range_proof(1, 0, blinding, commit, &message);
+        // secp.verify_range_proof(commit, range_proof).unwrap();
+        // let proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
+        // assert!(proof_info.success);
+        // assert_eq!(proof_info.min, 1);
+        // assert_eq!(proof_info.value, 1);
     }
 
     /// test that we can pass a message in when creating a range proof
@@ -715,27 +735,44 @@ mod tests {
         let blinding = SecretKey::new(&secp, &mut OsRng::new().unwrap());
         let commit = secp.commit(7, blinding).unwrap();
 
-        let message = ProofMessage{msg: vec![1, 2, 3, 4]};
-        let nonce = secp.nonce();
-        let range_proof = secp.range_proof(0, 7, blinding, commit, &message, nonce);
-        let mut proof_info = secp.rewind_range_proof(commit, range_proof, nonce);
+        let message = ProofMessage(vec![1, 2, 3, 4]);
+        let range_proof = secp.range_proof(0, 7, blinding, commit, &message);
+        let mut proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
 
         assert!(proof_info.success);
 
         proof_info.message.truncate(4);
         assert_eq!(proof_info.message, message);
-        assert_eq!(proof_info.message.msg, vec![1, 2, 3, 4]);
+        assert_eq!(proof_info.message, ProofMessage(vec![1, 2, 3, 4]));
 
         // now check we can pass in an arbitrary string as the message
         let message = ProofMessage::from_bytes(String::from("this is a test message").as_bytes());
-        let nonce = secp.nonce();
-        let range_proof = secp.range_proof(0, 7, blinding, commit, &message, nonce);
-        let mut proof_info = secp.rewind_range_proof(commit, range_proof, nonce);
-
-        assert!(proof_info.success);
+        let range_proof = secp.range_proof(0, 7, blinding, commit, &message);
+        let mut proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
 
         proof_info.message.truncate("this is a test message".len());
         assert_eq!(proof_info.message, message);
-        assert_eq!(String::from_utf8(proof_info.message.msg).unwrap(), "this is a test message");
+        assert_eq!(String::from_utf8(proof_info.message.as_bytes().to_vec()).unwrap(), "this is a test message");
+    }
+
+    #[test]
+    fn test_proof_message() {
+        let message = ProofMessage::empty();
+        assert_eq!(message.len(), 0);
+        assert_eq!(message.as_bytes().len(), 0);
+
+        let message = ProofMessage(vec![1, 2, 3, 4]);
+        assert_eq!(message.len(), 4);
+
+        let bytes = message.as_bytes();
+        assert_eq!(message.as_bytes(), [1, 2, 3, 4]);
+
+        assert_eq!(message, ProofMessage::from_bytes(bytes));
+
+        let mut message = ProofMessage(vec![1, 2, 3, 4]);
+        message.truncate(3);
+        assert_eq!(message.len(), 3);
+        assert_eq!(message.as_bytes(), [1, 2, 3]);
+        assert_eq!(message, ProofMessage(vec![1, 2, 3]));
     }
 }


### PR DESCRIPTION
The PR includes two things (might make sense to split it up) -
  * adds `message` support to `range_proof` (was previously just using zero'd out message)
  * uses `rewind_range_proof` to allow for recovery of the original unblinded output `value`

We use the secret key (blinding factor) originally used to generate the commitment as the `nonce` for the range proof - this "known key" allows the owner and only the owner to rewind the range proof and recover the value (and the message).

Related: #28 (wallet import/export format, specifically needing the privkey & value to recover wallet UTXOs)

Takes inspiration from Elements -
https://github.com/ElementsProject/elements/blob/8fed03f63ca2f46ea97e2f286a3bc46ce3087d6c/src/blind.cpp#L145
https://github.com/ElementsProject/elements/blob/8fed03f63ca2f46ea97e2f286a3bc46ce3087d6c/src/blind.cpp#L421

Some takeaways - 

The benchmarks indicate a single `rewind_range_proof` takes approx 14ms.
Without any way to identify UTXOs we'd need to try every UTXO with every possible secret key in the wallet - this is going to add up really quickly.

