### PR TITLE
fix the range_proof call (missing nonce param)

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -970,7 +970,7 @@ mod tests {
         transaction::Output{
             features: transaction::COINBASE_OUTPUT,
             commit: output_commitment,
-            proof: ec.range_proof(0, value, output_key, output_commitment)}
+            proof: ec.range_proof(0, value, output_key, output_commitment, ec.nonce())}
     }
 
     /// Makes a SecretKey from a single u64


### PR DESCRIPTION
Not sure what happened here (I think maybe I forgot to rebase one of my branches and a change got missed).

But master is failing right now (pool is not compiling)
https://travis-ci.org/ignopeverell/grin/jobs/274703501

This PR fixes this.