### PR TITLE
wallet now supports coinbase maturity

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -32,6 +32,8 @@ extern crate serde_json;
 pub mod client;
 mod endpoints;
 mod rest;
+mod types;
 
 pub use endpoints::start_rest_apis;
+pub use types::*;
 pub use rest::*;

--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -1,0 +1,85 @@
+// Copyright 2016 The Grin Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::{core, consensus};
+use chain;
+use secp::pedersen;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Tip {
+	/// Height of the tip (max height of the fork)
+	pub height: u64,
+	// Last block pushed to the fork
+	// pub last_block_h: Hash,
+	// Block previous to last
+	// pub prev_block_h: Hash,
+	// Total difficulty accumulated on that fork
+	// pub total_difficulty: Difficulty,
+}
+
+impl Tip {
+	pub fn from_tip(tip: chain::Tip) -> Tip {
+		Tip {
+			height: tip.height,
+		}
+	}
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum OutputType {
+	Coinbase,
+	Transaction,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Output {
+	/// The type of output Coinbase|Transaction
+	pub output_type: OutputType,
+	/// The homomorphic commitment representing the output's amount
+	pub commit: pedersen::Commitment,
+	/// A proof that the commitment is in the right range
+	pub proof: pedersen::RangeProof,
+	/// The height of the block creating this output
+	pub height: u64,
+	/// The lock height (spendable after block)
+	pub lock_height: u64,
+}
+
+impl Output {
+	pub fn from_output(output: &core::Output, block_header: &core::BlockHeader) -> Output {
+		let (output_type, maturity) = match output.features {
+			x if x.contains(core::transaction::COINBASE_OUTPUT) => {
+				(OutputType::Coinbase, consensus::COINBASE_MATURITY)
+			},
+			_ => (OutputType::Transaction, 0),
+		};
+		Output {
+			output_type: output_type,
+			commit: output.commit,
+			proof: output.proof,
+			height: block_header.height,
+			lock_height: block_header.height + maturity,
+		}
+	}
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PoolInfo {
+	/// Size of the pool
+	pub pool_size: usize,
+	/// Size of orphans
+	pub orphans_size: usize,
+	/// Total size of pool + orphans
+	pub total_size: usize,
+}

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -30,9 +30,8 @@ use std::cmp::Ordering;
 use secp::{self, Secp256k1};
 use secp::pedersen::*;
 
-pub use self::block::{Block, BlockHeader, DEFAULT_BLOCK};
-pub use self::transaction::{Transaction, Input, Output, TxKernel, COINBASE_KERNEL,
-                            COINBASE_OUTPUT, DEFAULT_OUTPUT};
+pub use self::block::*;
+pub use self::transaction::*;
 use self::hash::{Hash, Hashed, ZERO_HASH};
 use ser::{Writeable, Writer, Reader, Readable, Error};
 

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -169,6 +169,8 @@ fn receive_coinbase(config: &WalletConfig, ext_key: &ExtendedKey, amount: u64) -
 			n_child: coinbase_key.n_child,
 			value: amount,
 			status: OutputStatus::Unconfirmed,
+			height: 0,
+			lock_height: 0,
 		});
 		debug!("Using child {} for a new coinbase output.",
 		       coinbase_key.n_child);
@@ -207,6 +209,8 @@ fn receive_transaction(config: &WalletConfig,
 			n_child: out_key.n_child,
 			value: amount,
 			status: OutputStatus::Unconfirmed,
+			height: 0,
+			lock_height: 0,
 		});
 
 		debug!("Using child {} for a new transaction output.",

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -28,7 +28,7 @@ use api;
 /// UTXOs. The destination can be "stdout" (for command line) or a URL to the
 /// recipients wallet receiver (to be implemented).
 pub fn issue_send_tx(config: &WalletConfig, ext_key: &ExtendedKey, amount: u64, dest: String) -> Result<(), Error> {
-	checker::refresh_outputs(&config, ext_key);
+	let _ = checker::refresh_outputs(&config, ext_key);
 
 	let (tx, blind_sum) = build_send_tx(config, ext_key, amount)?;
 	let json_tx = partial_tx_to_json(amount, blind_sum, tx);
@@ -82,6 +82,8 @@ fn build_send_tx(config: &WalletConfig, ext_key: &ExtendedKey, amount: u64) -> R
 			n_child: change_key.n_child,
 			value: change as u64,
 			status: OutputStatus::Unconfirmed,
+			height: 0,
+			lock_height: 0,
 		});
 		for mut coin in coins {
 			coin.lock();
@@ -118,6 +120,8 @@ mod test {
 			n_child: out_key.n_child,
 			value: 5,
 			status: OutputStatus::Unconfirmed,
+			height: 0,
+			lock_height: 0,
 		};
 
 		let (tx, _) = transaction(vec![output(coin.value, out_key.key)]).unwrap();

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -108,6 +108,7 @@ impl Default for WalletConfig {
 pub enum OutputStatus {
 	Unconfirmed,
 	Unspent,
+	Immature,
 	Locked,
 	Spent,
 }
@@ -125,6 +126,9 @@ pub struct OutputData {
 	pub value: u64,
 	/// Current status of the output
 	pub status: OutputStatus,
+	/// Height of the output
+	pub height: u64,
+	pub lock_height: u64,
 }
 
 impl OutputData {


### PR DESCRIPTION
Coinbase outputs cannot be spent until COINBASE_MATURITY blocks have been added to the chain.
This PR makes the wallet aware of this via height and lock_height in the utxo api response.

* wallet will not select coinbase outputs to spend until they have matured
* introduce `Tip` and `Output` structs in api (decouple api serialization/deserialization from core)
* Output struct includes `height` and `lock_height` based on `block_header.height`
* introduce `Immature` output status in wallet
