### PR TITLE
add new CoinbaseReserved output status in wallet

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -460,9 +460,10 @@ impl Block {
 
 	/// Builds the blinded output and related signature proof for the block
 	/// reward.
-	pub fn reward_output(skey: secp::key::SecretKey,
-	                     secp: &Secp256k1)
-	                     -> Result<(Output, TxKernel), secp::Error> {
+	pub fn reward_output(
+		skey: secp::key::SecretKey,
+		secp: &Secp256k1
+	) -> Result<(Output, TxKernel), secp::Error> {
 		let msg = try!(secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE]));
 		let sig = try!(secp.sign(&msg, &skey));
 		let commit = secp.commit(REWARD, skey).unwrap();

--- a/grin/src/lib.rs
+++ b/grin/src/lib.rs
@@ -54,6 +54,5 @@ mod seed;
 mod sync;
 mod types;
 mod miner;
-
 pub use server::{Server};
 pub use types::{ServerConfig, Seeding, ServerStats};

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -17,6 +17,7 @@ use std::convert::From;
 use api;
 use chain;
 use p2p;
+use secp;
 use store;
 use pow;
 use core::global::MiningParameterMode;
@@ -32,6 +33,8 @@ pub enum Error {
 	P2P(p2p::Error),
 	/// Error originating from HTTP API calls
 	API(api::Error),
+	/// Error originating from underlying secp lib
+	Secp(secp::Error),
 }
 
 impl From<chain::Error> for Error {
@@ -127,4 +130,3 @@ pub struct ServerStats {
 	/// Chain head
 	pub head: chain::Tip,
 }
-

--- a/wallet/src/checker.rs
+++ b/wallet/src/checker.rs
@@ -32,7 +32,7 @@ fn refresh_output(
 		out.lock_height = api_out.lock_height;
 
 		if out.status == OutputStatus::Locked {
-			// leave it Locked locally for now
+			// leave it Locked locally for now - waiting for it to be spent
 		} else if api_out.lock_height >= tip.height {
 			out.status = OutputStatus::Immature;
 		} else {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -107,6 +107,8 @@ impl Default for WalletConfig {
 /// broadcasted or mined).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum OutputStatus {
+	/// Reserved by miner for potential coinbase output.
+	CoinbaseReserved,
 	Unconfirmed,
 	Unspent,
 	Immature,


### PR DESCRIPTION
Every time the miner process is started up we create a new coinbase output in the wallet.
This was really confusing as these were labeled "Unconfirmed" yet may never be confirmed.

This introduces a new `MinerReserved` output status to help differentiate between these miner reserved coinbase outputs and real unconfirmed outputs.

Also added a (hardcoded) `amount=1` miner fee to partial transactions created by the wallet to exercise the transaction fee handling code and to make outputs + change outputs more realistic during testing.

A basic txn generates - 
* output to receiving party
* change output to sender
* a fee (no output, burnt by the network)
* a coinbase reward output in the block containing the txn

Coinbase outputs now look like this in `wallet info` prior to the miner actually mining a block and successfully claiming the reward - 

```
grin wallet info
Outputs - 
fingerprint, n_child, height, lock_height, status, value
----------------------------------
fc385d28, 1, 0, 0, CoinbaseReserved, 1000000000
d17777d9, 2, 0, 0, CoinbaseReserved, 1000000000
b03b50c1, 3, 0, 0, CoinbaseReserved, 1000000000
3d225151, 4, 1, 4, Immature, 1000000000
eb68319f, 5, 0, 0, CoinbaseReserved, 1000000000
```

I can split this into 2 separate PRs if we want to keep the fee out of this for now.
