### PR TITLE
cuckoo miner update

### DIFF
--- a/grin.toml
+++ b/grin.toml
@@ -54,7 +54,7 @@ port = 13414
 
 #flag whether mining is enabled
 
-enable_mining = true
+enable_mining = false
 
 #Whether to use cuckoo-miner,  and related parameters
 

--- a/grin.toml
+++ b/grin.toml
@@ -62,9 +62,7 @@ use_cuckoo_miner = true
 
 #Whether to use async mode for cuckoo miner, if the plugin supports it.
 #this allows for many searches to be run in parallel, e.g. if the system
-#has multiple GPUs. This creates overhead, especially on faster test miners,
-#so in a post-release world this should only be used if you really want
-#to run cards in parallel
+#has multiple GPUs, or if you want to mine using multiple plugins 
 
 cuckoo_miner_async_mode = false
 
@@ -108,9 +106,17 @@ burn_reward = true
 # single GPU and single CPU plugin in parallel
 
 #The fastest cpu algorithm, but consumes the most memory
+#Also requires instructions that aren't available on
+#older processors. In this case, use mean_compat_cpu
+#instead
+#[[mining.cuckoo_miner_plugin_config]]
+#type_filter = "mean_cpu"
+#parameter_list = {NUM_THREADS=4, NUM_TRIMS=64}
 
+#Same as above, but for older processors. Will be slightly
+#slower.
 [[mining.cuckoo_miner_plugin_config]]
-type_filter = "mean_cpu"
+type_filter = "mean_compat_cpu"
 parameter_list = {NUM_THREADS=4, NUM_TRIMS=64}
 
 #note lean_cpu currently has a bug which prevents it from

--- a/grin.toml
+++ b/grin.toml
@@ -54,7 +54,7 @@ port = 13414
 
 #flag whether mining is enabled
 
-enable_mining = true
+enable_mining = false 
 
 #Whether to use cuckoo-miner,  and related parameters
 

--- a/grin.toml
+++ b/grin.toml
@@ -54,7 +54,7 @@ port = 13414
 
 #flag whether mining is enabled
 
-enable_mining = false
+enable_mining = true
 
 #Whether to use cuckoo-miner,  and related parameters
 
@@ -111,13 +111,13 @@ burn_reward = true
 #instead
 #[[mining.cuckoo_miner_plugin_config]]
 #type_filter = "mean_cpu"
-#parameter_list = {NUM_THREADS=4, NUM_TRIMS=64}
+#parameter_list = {NUM_THREADS=4, NUM_TRIMS=68}
 
 #Same as above, but for older processors. Will be slightly
 #slower.
 [[mining.cuckoo_miner_plugin_config]]
 type_filter = "mean_compat_cpu"
-parameter_list = {NUM_THREADS=4, NUM_TRIMS=64}
+parameter_list = {NUM_THREADS=4, NUM_TRIMS=68}
 
 #note lean_cpu currently has a bug which prevents it from
 #working with threads > 1

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -231,6 +231,9 @@ impl Miner {
 					next_stat_output = time::get_time().sec + stat_output_interval;
 				}
 			}
+			//avoid busy wait
+			let sleep_dur = std::time::Duration::from_millis(100);
+			thread::sleep(sleep_dur);
 		}
 		if sol == None {
 			debug!(

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,7 +18,7 @@ grin_core = { path = "../core" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="grin_integration_10"
+tag="grin_integration_11"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,7 +18,7 @@ grin_core = { path = "../core" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="grin_integration_11"
+tag="grin_integration_12"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,7 +18,7 @@ grin_core = { path = "../core" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="grin_integration_9"
+tag="grin_integration_10"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]


### PR DESCRIPTION
-update cuckoo miner tag
-add 'compatible' version of mean_miner for older processors, and make it default (need someone to test this)
-turn off mining in default grin.toml, so people who want to mine are forced to look at the config options a bit
-fixing a lot of 'busy wait' conditions that were slowing down mining in async mode throughout