### PR TITLE
Fix deprecated futures items

### DIFF
--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -17,8 +17,8 @@ grin_pow = { path = "../pow" }
 secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 
 env_logger="^0.3.5"
-futures = "^0.1.9"
-futures-cpupool = "^0.1.3"
+futures = "^0.1.16"
+futures-cpupool = "^0.1.16"
 hyper = { git = "https://github.com/hyperium/hyper" }
 log = "^0.3"
 time = "^0.1"

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -17,8 +17,8 @@ grin_pow = { path = "../pow" }
 secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 
 env_logger="^0.3.5"
-futures = "^0.1.16"
-futures-cpupool = "^0.1.16"
+futures = "^0.1.15"
+futures-cpupool = "^0.1.3"
 hyper = { git = "https://github.com/hyperium/hyper" }
 log = "^0.3"
 time = "^0.1"

--- a/grin/src/seed.rs
+++ b/grin/src/seed.rs
@@ -118,7 +118,7 @@ impl Seeder {
 						thread_rng().shuffle(&mut peers[..]);
 						let sz = min(PEER_PREFERRED_COUNT as usize, peers.len());
 						for p in &peers[0..sz] {
-							tx.send(p.addr).unwrap();
+							tx.unbounded_send(p.addr).unwrap();
 						}
 					}
 				}
@@ -165,7 +165,7 @@ impl Seeder {
 				let sz = min(PEER_PREFERRED_COUNT as usize, peer_addrs.len());
 				for addr in &peer_addrs[0..sz] {
 					debug!("Connecting to seed: {}.", addr);
-					tx.send(*addr).unwrap();
+					tx.unbounded_send(*addr).unwrap();
 				}
 				if peer_addrs.len() == 0 {
 					warn!("No seeds were retrieved.");

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 [dependencies]
 bitflags = "^0.7.0"
 byteorder = "^0.5"
-futures = "^0.1.16"
+futures = "^0.1.15"
 log = "^0.3"
 net2 = "0.2.0"
 rand = "^0.3"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 [dependencies]
 bitflags = "^0.7.0"
 byteorder = "^0.5"
-futures = "^0.1.9"
+futures = "^0.1.16"
 log = "^0.3"
 net2 = "0.2.0"
 rand = "^0.3"

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -183,7 +183,7 @@ impl Connection {
 
 		// infinite iterator stream so we repeat the message reading logic until the
 		// peer is stopped
-		let iter = stream::iter(iter::repeat(()).map(Ok::<(), Error>));
+		let iter = stream::iter_ok(iter::repeat(()).map(Ok::<(), Error>));
 
 		// setup the reading future, getting messages from the peer and processing them
 		let recv_bytes = self.received_bytes.clone();

--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -238,7 +238,7 @@ impl Connection {
 		));
 		data.append(&mut body_data);
 
-		self.outbound_chan.send(data).map_err(
+		self.outbound_chan.unbounded_send(data).map_err(
 			|_| Error::ConnectionClose,
 		)
 	}

--- a/p2p/src/protocol.rs
+++ b/p2p/src/protocol.rs
@@ -134,7 +134,7 @@ fn handle_payload(
 	match header.msg_type {
 		Type::Ping => {
 			let data = ser::ser_vec(&MsgHeader::new(Type::Pong, 0))?;
-			sender.send(data).unwrap();
+			sender.unbounded_send(data).unwrap();
 			Ok(None)
 		}
 		Type::Pong => Ok(None),
@@ -156,7 +156,7 @@ fn handle_payload(
 					&MsgHeader::new(Type::Block, body_data.len() as u64),
 				));
 				data.append(&mut body_data);
-				sender.send(data).unwrap();
+				sender.unbounded_send(data).unwrap();
 			}
 			Ok(None)
 		}
@@ -183,7 +183,7 @@ fn handle_payload(
 				&MsgHeader::new(Type::Headers, body_data.len() as u64),
 			));
 			data.append(&mut body_data);
-			sender.send(data).unwrap();
+			sender.unbounded_send(data).unwrap();
 
 			Ok(None)
 		}
@@ -210,7 +210,7 @@ fn handle_payload(
 				&MsgHeader::new(Type::PeerAddrs, body_data.len() as u64),
 			));
 			data.append(&mut body_data);
-			sender.send(data).unwrap();
+			sender.unbounded_send(data).unwrap();
 
 			Ok(None)
 		}


### PR DESCRIPTION
`futures` v0.1.15 deprecated two items used in Grin, replacing them with more verbose names to avoid confusion and simplify functionality. As a result, new installs of Grin grabbing the latest version of `futures` gave numerous warnings like the following:

    warning: use of deprecated item: renamed to `unbound_send`

and

    warning: use of deprecated item: implementation moved to `iter_ok`

This PR updates the minimum requirement for `futures` to the most recent release, v0.1.16, and takes care of these warnings without breaking functionality. I have also bumped the minimum version for `futures-cpupool`, primarily so both projects are synchronized.

More info on the relevant changes to `futures` here: https://github.com/alexcrichton/futures-rs/blob/master/CHANGELOG.md#0115---2017-08-24