### PR TITLE
specify fee in receive_transaction

### DIFF
--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -215,10 +215,16 @@ fn receive_transaction(
 		let next_child = wallet_data.next_child(&ext_key.fingerprint);
 		let out_key = ext_key.derive(&secp, next_child).map_err(|e| Error::Key(e))?;
 
+		// TODO - replace with real fee calculation
+		// TODO - note we are not enforcing this in consensus anywhere yet
+		let fee_amount = 1;
+		let out_amount = amount - fee_amount;
+
 		let (tx_final, _) = build::transaction(vec![
 			build::initial_tx(partial),
 			build::with_excess(blinding),
-			build::output(amount, out_key.key),
+			build::output(out_amount, out_key.key),
+			build::with_fee(fee_amount),
 		])?;
 
 		// make sure the resulting transaction is valid (could have been lied to
@@ -229,7 +235,7 @@ fn receive_transaction(
 		wallet_data.append_output(OutputData {
 			fingerprint: out_key.fingerprint,
 			n_child: out_key.n_child,
-			value: amount,
+			value: out_amount,
 			status: OutputStatus::Unconfirmed,
 			height: 0,
 			lock_height: 0,


### PR DESCRIPTION
Results in the following - 

1) send `50` to myself
1) spending a `1000000000` coinbase
1) receive `49`
1) burning `1` in fees
1) receive `999999950` in change

```
Outputs - 
fingerprint, n_child, height, lock_height, status, value
----------------------------------
fd997546, 1, 1, 4, Spent, 1000000000
15d2f09b, 2, 2, 5, Unspent, 1000000000
6040547d, 3, 3, 6, Unspent, 1000000000
8d3f2247, 4, 4, 7, Immature, 1000000000
abfb3af7, 5, 5, 8, Immature, 1000000000
ac6a91ce, 6, 6, 9, Immature, 1000000000
3177752d, 7, 7, 0, Unspent, 999999950
712e0ddc, 8, 7, 0, Unspent, 49
4cc0d030, 9, 7, 10, Immature, 1000000000
948ca690, 10, 0, 0, Unconfirmed, 1000000000
```
