### PR TITLE
Cuckoo miner

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::{core, consensus};
+use core::{core, consensus, global};
 use chain;
 use secp::pedersen;
 
@@ -60,7 +60,7 @@ impl Output {
 			x if x.contains(core::transaction::COINBASE_OUTPUT) => {
 				(
 					OutputType::Coinbase,
-					block_header.height + consensus::COINBASE_MATURITY,
+					block_header.height + global::coinbase_maturity(),
 				)
 			}
 			_ => (OutputType::Transaction, 0),

--- a/chain/src/pipe.rs
+++ b/chain/src/pipe.rs
@@ -271,7 +271,7 @@ fn validate_block(
 
 					// TODO - make sure we are not off-by-1 here vs. the equivalent tansaction
 					// validation rule
-					if b.header.height <= output_header.height + consensus::COINBASE_MATURITY {
+					if b.header.height <= output_header.height + global::coinbase_maturity() {
 						return Err(Error::ImmatureCoinbase);
 					}
 				};

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -27,10 +27,7 @@ use core::target::Difficulty;
 pub const REWARD: u64 = 1_000_000_000;
 
 /// Number of blocks before a coinbase matures and can be spent
-/// TODO - reduced this for testing - need to investigate if we can lower this
-/// in test env
-// pub const COINBASE_MATURITY: u64 = 1_000;
-pub const COINBASE_MATURITY: u64 = 3;
+pub const COINBASE_MATURITY: u64 = 1_000;
 
 /// Block interval, in seconds, the network will tune its next_target for. Note
 /// that we may reduce this value in the future as we get more data on mining

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -42,10 +42,10 @@ pub const USER_TESTING_SIZESHIFT: u8 = 16;
 pub const USER_TESTING_PROOF_SIZE: usize = 42;
 
 /// Automated testing coinbase maturity
-pub const AUTOMATED_TESTING_COINBASE_MATURITY:u64 = 3;
+pub const AUTOMATED_TESTING_COINBASE_MATURITY: u64 = 3;
 
 /// User testing coinbase maturity
-pub const USER_TESTING_COINBASE_MATURITY:u64 = 3;
+pub const USER_TESTING_COINBASE_MATURITY: u64 = 3;
 
 /// Mining parameter modes
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/core/src/global.rs
+++ b/core/src/global.rs
@@ -24,6 +24,7 @@
 use std::sync::RwLock;
 use consensus::PROOFSIZE;
 use consensus::DEFAULT_SIZESHIFT;
+use consensus::COINBASE_MATURITY;
 
 /// Define these here, as they should be developer-set, not really tweakable
 /// by users
@@ -39,6 +40,12 @@ pub const USER_TESTING_SIZESHIFT: u8 = 16;
 
 /// User testing proof size
 pub const USER_TESTING_PROOF_SIZE: usize = 42;
+
+/// Automated testing coinbase maturity
+pub const AUTOMATED_TESTING_COINBASE_MATURITY:u64 = 3;
+
+/// User testing coinbase maturity
+pub const USER_TESTING_COINBASE_MATURITY:u64 = 3;
 
 /// Mining parameter modes
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,6 +89,16 @@ pub fn proofsize() -> usize {
 		MiningParameterMode::AutomatedTesting => AUTOMATED_TESTING_PROOF_SIZE,
 		MiningParameterMode::UserTesting => USER_TESTING_PROOF_SIZE,
 		MiningParameterMode::Production => PROOFSIZE,
+	}
+}
+
+/// Coinbase maturity
+pub fn coinbase_maturity() -> u64 {
+	let param_ref = MINING_PARAMETER_MODE.read().unwrap();
+	match *param_ref {
+		MiningParameterMode::AutomatedTesting => AUTOMATED_TESTING_COINBASE_MATURITY,
+		MiningParameterMode::UserTesting => USER_TESTING_COINBASE_MATURITY,
+		MiningParameterMode::Production => COINBASE_MATURITY,
 	}
 }
 

--- a/grin.toml
+++ b/grin.toml
@@ -31,10 +31,10 @@ seeding_type = "None"
 #The mining parameter mode, which defines the set of cuckoo parameters
 #used for mining. Can be:
 #AutomatedTesting - For CI builds and instant blockchain creation
-#UserTesting - For regular user testing, much lighter than production more
-#Production - Full production cuckoo parameters
+#UserTesting - For regular user testing (cuckoo 16)
+#Production - Full production cuckoo parameter (cuckoo 30)
 
-mining_parameter_mode = "Production"
+mining_parameter_mode = "UserTesting"
 
 #7 = Bit flags for FULL_NODE, this structure needs to be changed
 #internally to make it more configurable
@@ -54,7 +54,7 @@ port = 13414
 
 #flag whether mining is enabled
 
-enable_mining = false 
+enable_mining = false
 
 #Whether to use cuckoo-miner,  and related parameters
 
@@ -128,6 +128,11 @@ parameter_list = {NUM_THREADS=4, NUM_TRIMS=68}
 
 #CUDA verion of lean miner
 #Can currently be used only in Production (30) Mode
+#This plugin is not built by default. To build:
+#1) Ensure the latest cuda toolkit is installed
+#   (nvcc should be on the pat)
+#2) Uncomment the 'build-cuda-plugin' feature
+#   in pow/Cargo.toml
 
 #[[mining.cuckoo_miner_plugin_config]]
 #type_filter = "lean_cuda"

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -20,6 +20,7 @@ pub use graph;
 use core::core::transaction;
 use core::core::block;
 use core::core::hash;
+use core::global;
 use core::consensus;
 
 use secp;
@@ -168,7 +169,7 @@ where
 						{
 							if let Ok(head_header) = self.blockchain.head_header() {
 								if head_header.height <=
-									out_header.height + consensus::COINBASE_MATURITY
+									out_header.height + global::coinbase_maturity()
 								{
 									return Err(PoolError::ImmatureCoinbase {
 										header: out_header,

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -21,6 +21,7 @@ use core::core::transaction;
 use core::core::block;
 use core::core::hash;
 use core::global;
+use core::global::{MiningParameterMode, MINING_PARAMETER_MODE};
 use core::consensus;
 
 use secp;
@@ -728,6 +729,7 @@ mod tests {
 
 	#[test]
 	fn test_immature_coinbase() {
+		global::set_mining_mode(MiningParameterMode::AutomatedTesting);
 		let mut dummy_chain = DummyChainImpl::new();
 		let coinbase_output = test_coinbase_output(15);
 		dummy_chain.update_utxo_set(DummyUtxoSet::empty().with_output(coinbase_output));

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,10 +18,12 @@ grin_core = { path = "../core" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="grin_integration_12"
+tag="grin_integration_13"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]
+#uncomment this feature to enable cuda builds (cuda toolkit must be installed)
+#features=["build-cuda-plugins"]
 
 [dev_dependencies]
 grin_chain = { path = "../chain"}


### PR DESCRIPTION
* Fix for https://github.com/ignopeverell/grin/issues/152 (within cuckoo-miner)
* Implement https://github.com/ignopeverell/grin/issues/133, coinbase maturity changes with mining parameter mode
* Latest @tromp fixes to mean miner
* Cuda plugins aren't built by default now, even if cuda toolkit is installed. Feature added to cuckoo-miner to turn them on, which can be flicked in pow/Cargo.toml