### PR TITLE
rust-secp256k1-zkp now supports recovering message and value from range proof

### DIFF
--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -484,9 +484,10 @@ impl Block {
 		let msg = secp::Message::from_slice(&[0; secp::constants::MESSAGE_SIZE])?;
 		let sig = keychain.sign(&msg, &pubkey)?;
 		let commit = keychain.commit(REWARD, &pubkey)?;
+		let msg = secp::pedersen::ProofMessage::empty();
 		// let switch_commit = keychain.switch_commit(pubkey)?;
 
-		let rproof = keychain.range_proof(REWARD, &pubkey, commit)?;
+		let rproof = keychain.range_proof(REWARD, &pubkey, commit, msg)?;
 
 		let output = Output {
 			features: COINBASE_OUTPUT,

--- a/core/src/core/build.rs
+++ b/core/src/core/build.rs
@@ -55,7 +55,8 @@ pub fn input(value: u64, pubkey: Identifier) -> Box<Append> {
 pub fn output(value: u64, pubkey: Identifier) -> Box<Append> {
 	Box::new(move |build, (tx, sum)| -> (Transaction, BlindSum) {
 		let commit = build.keychain.commit(value, &pubkey).unwrap();
-		let rproof = build.keychain.range_proof(value, &pubkey, commit).unwrap();
+		let msg = secp::pedersen::ProofMessage::empty();
+		let rproof = build.keychain.range_proof(value, &pubkey, commit, msg).unwrap();
 
 		(tx.with_output(Output {
 			features: DEFAULT_OUTPUT,

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -17,7 +17,7 @@ use rand::{thread_rng, Rng};
 use secp;
 use secp::{Message, Secp256k1, Signature};
 use secp::key::SecretKey;
-use secp::pedersen::{Commitment, RangeProof};
+use secp::pedersen::{Commitment, ProofMessage, ProofInfo, RangeProof};
 use blake2;
 
 use blind::{BlindingFactor, BlindSum};
@@ -107,11 +107,21 @@ impl Keychain {
 		amount: u64,
 		pubkey: &Identifier,
 		commit: Commitment,
+		msg: ProofMessage,
 	) -> Result<RangeProof, Error> {
 		let skey = self.derived_key(pubkey)?;
-		let nonce = self.secp.nonce();
-		let range_proof = self.secp.range_proof(0, amount, skey, commit, nonce);
+		let range_proof = self.secp.range_proof(0, amount, skey, commit, msg);
 		Ok(range_proof)
+	}
+
+	pub fn rewind_range_proof(
+		&self,
+		pubkey: &Identifier,
+		commit: Commitment,
+		proof: RangeProof,
+	) -> Result<ProofInfo, Error> {
+		let nonce = self.derived_key(pubkey)?;
+		Ok(self.secp.rewind_range_proof(commit, proof, nonce))
 	}
 
 	pub fn blind_sum(&self, blind_sum: &BlindSum) -> Result<BlindingFactor, Error> {
@@ -167,11 +177,11 @@ impl Keychain {
 mod test {
 	use keychain::Keychain;
 	use secp;
+	use secp::pedersen::ProofMessage;
 
 	#[test]
 	fn test_key_derivation() {
 		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-
 		let keychain = Keychain::from_random_seed().unwrap();
 
 		// use the keychain to derive a "pubkey" based on the underlying seed
@@ -187,5 +197,44 @@ mod test {
 		// now check we can use our key to verify a signature from this zero commitment
 		let sig = keychain.sign(&msg, &pubkey).unwrap();
 		secp.verify_from_commit(&msg, &sig, &commit).unwrap();
+	}
+
+	#[test]
+	fn test_rewind_range_proof() {
+		let keychain = Keychain::from_random_seed().unwrap();
+		let pubkey = keychain.derive_pubkey(1).unwrap();
+		let commit = keychain.commit(5, &pubkey).unwrap();
+		let msg = ProofMessage::empty();
+
+		let proof = keychain.range_proof(5, &pubkey, commit, msg).unwrap();
+		let proof_info = keychain.rewind_range_proof(&pubkey, commit, proof).unwrap();
+
+		assert_eq!(proof_info.success, true);
+		assert_eq!(proof_info.value, 5);
+
+		// now check the recovered message is "empty" (but not truncated) i.e. all zeroes
+		assert_eq!(
+			proof_info.message,
+			secp::pedersen::ProofMessage::from_bytes(&[0; secp::constants::PROOF_MSG_SIZE])
+		);
+
+		let pubkey2 = keychain.derive_pubkey(2).unwrap();
+
+		// cannot rewind with a different nonce
+		let proof_info = keychain.rewind_range_proof(&pubkey2, commit, proof).unwrap();
+		assert_eq!(proof_info.success, false);
+		assert_eq!(proof_info.value, 0);
+
+		// cannot rewind with a commitment to the same value using a different key
+		let commit2 = keychain.commit(5, &pubkey2).unwrap();
+		let proof_info = keychain.rewind_range_proof(&pubkey, commit2, proof).unwrap();
+		assert_eq!(proof_info.success, false);
+		assert_eq!(proof_info.value, 0);
+
+		// cannot rewind with a commitment to a different value
+		let commit3 = keychain.commit(4, &pubkey).unwrap();
+		let proof_info = keychain.rewind_range_proof(&pubkey, commit3, proof).unwrap();
+		assert_eq!(proof_info.success, false);
+		assert_eq!(proof_info.value, 0);
 	}
 }

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -561,6 +561,7 @@ mod tests {
 	use types::*;
 	use core::core::build;
 	use blockchain::{DummyChain, DummyChainImpl, DummyUtxoSet};
+	use secp;
 	use keychain::Keychain;
 	use std::sync::{Arc, RwLock};
 	use blake2;
@@ -1074,7 +1075,8 @@ mod tests {
 		let keychain = keychain_for_tests();
 		let pubkey = keychain.derive_pubkey(value as u32).unwrap();
 		let commit = keychain.commit(value, &pubkey).unwrap();
-		let proof = keychain.range_proof(value, &pubkey, commit).unwrap();
+		let msg = secp::pedersen::ProofMessage::empty();
+		let proof = keychain.range_proof(value, &pubkey, commit, msg).unwrap();
 
 		transaction::Output {
 			features: transaction::DEFAULT_OUTPUT,
@@ -1088,7 +1090,8 @@ mod tests {
 		let keychain = keychain_for_tests();
 		let pubkey = keychain.derive_pubkey(value as u32).unwrap();
 		let commit = keychain.commit(value, &pubkey).unwrap();
-		let proof = keychain.range_proof(value, &pubkey, commit).unwrap();
+		let msg = secp::pedersen::ProofMessage::empty();
+		let proof = keychain.range_proof(value, &pubkey, commit, msg).unwrap();
 
 		transaction::Output {
 			features: transaction::COINBASE_OUTPUT,


### PR DESCRIPTION
This PR makes the necessary changes in Grin to support the changes in rust-secp256k1-zkp.

* Adds `recover_value` to Output
* Adds `rewind_range_proof` to Keychain

See related PR here - mimblewimble/rust-secp256k1-zkp#8

__Note:__ secp changes break backward compatibility and these PRs need to be coordinated.