### PR TITLE
wee warning cleanup + build doc updates

### DIFF
--- a/api/src/types.rs
+++ b/api/src/types.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::{core, consensus, global};
+use core::{core, global};
 use chain;
 use secp::pedersen;
 

--- a/chain/src/types.rs
+++ b/chain/src/types.rs
@@ -16,7 +16,6 @@
 
 use std::io;
 
-use secp;
 use secp::pedersen::Commitment;
 
 use grin_store as store;

--- a/doc/build.md
+++ b/doc/build.md
@@ -38,19 +38,20 @@ In order to compile and run Grin on your machine, you should have installed:
 
 ### Cuckoo-Miner considerations
 
-    If you're having issues with building cuckoo-miner plugins (which will usually manifest as a lot of C errors when building the `grin_pow` crate, you can turn mining plugin builds off by editing the file `pow/Cargo.toml' as follows:
+If you're having issues with building cuckoo-miner plugins (which will usually manifest as a lot of C errors when building the `grin_pow` crate, you can turn mining plugin builds off by editing the file `pow/Cargo.toml' as follows:
 
 ```
 #uncomment this feature to turn off plugin builds
 features=["no-plugin-build"]
 ```
 
-    This may help when building on 32 bit systems or non x86 architectures. You can still use the internal miner to mine by setting:
+This may help when building on 32 bit systems or non x86 architectures. You can still use the internal miner to mine by setting:
+
 ```
 use_cuckoo_miner = true
 ```
 
-    In `grin.toml`
+In `grin.toml`
 
 ## What have I just built?
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -6,7 +6,7 @@
 
 Note that it's still too early in development to declare 'officially supported' plaforms, but at the moment, the situation is:
 
-* Linux - Primary platform, as most development and testing is happening here
+* Linux - Primary platform (x86 only, at present), as most development and testing is happening here
 * Mac OS - Known to work, but may be slight hiccups
 * Windows - Known to compile, but working status unknown, and not a focus for the development team at present. Note that no mining plugins will be present on a Windows system after building Grin.
 
@@ -56,7 +56,7 @@ from the build directory will run grin using the defaults in the grin.toml file,
 For the time being, it's recommended just to put the built version of grin on your path, e.g. via:
 
 ```
-export $PATH=/path/to/grin/dir/target/grin:$PATH
+export PATH=/path/to/grin/dir/target/debug/grin:$PATH
 ```
 
 # Configuration

--- a/doc/build.md
+++ b/doc/build.md
@@ -36,6 +36,22 @@ In order to compile and run Grin on your machine, you should have installed:
     cd grin
     cargo build
 
+### Cuckoo-Miner considerations
+
+    If you're having issues with building cuckoo-miner plugins (which will usually manifest as a lot of C errors when building the `grin_pow` crate, you can turn mining plugin builds off by editing the file `pow/Cargo.toml' as follows:
+
+```
+#uncomment this feature to turn off plugin builds
+features=["no-plugin-build"]
+```
+
+    This may help when building on 32 bit systems or non x86 architectures. You can still use the internal miner to mine by setting:
+```
+use_cuckoo_miner = true
+```
+
+    In `grin.toml`
+
 ## What have I just built?
 
 Provided all of the prerequisites were installed and there were no issues, there should be 3 things in your project directory that you need to pay attention to in order to configure and run grin. These are:

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -20,7 +20,6 @@ use std::collections::HashMap;
 use secp::pedersen::Commitment;
 
 use time;
-use rand;
 
 use std::fmt;
 

--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -249,6 +249,7 @@ mod tests {
 	use super::*;
 	use secp;
 	use keychain::Keychain;
+	use rand;
 
 	#[test]
 	fn test_add_entry() {

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -21,8 +21,6 @@ use core::core::transaction;
 use core::core::block;
 use core::core::hash;
 use core::global;
-use core::global::{MiningParameterMode, MINING_PARAMETER_MODE};
-use core::consensus;
 
 use secp;
 use secp::pedersen::Commitment;

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -129,7 +129,7 @@ where
 	) -> Result<(), PoolError> {
 		// Making sure the transaction is valid before anything else.
 		let secp = secp::Secp256k1::with_caps(secp::ContextFlag::Commit);
-		tx.validate(&secp).map_err(|e| PoolError::Invalid)?;
+		tx.validate(&secp).map_err(|_e| PoolError::Invalid)?;
 
 		// The first check involves ensuring that an identical transaction is
 		// not already in the pool's transaction set.

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -563,6 +563,7 @@ mod tests {
 	use keychain::Keychain;
 	use std::sync::{Arc, RwLock};
 	use blake2;
+	use core::global::MiningParameterMode;
 
 	macro_rules! expect_output_parent {
 		($pool:expr, $expected:pat, $( $output:expr ),+ ) => {


### PR DESCRIPTION
Because loads of warnings imply the developers don't care, which is not the case in this instance. 

Edit: fixed, no warning now, except for an annoying 'redundant linker flag' thing, which I think is coming from rocksdb, so might be stuck there. Also slipping in these fixes to the build doc:

* information on what to do if cuckoo miner build fails
* state that target arch is currently x86
* path statement corrected from conversation in https://github.com/ignopeverell/grin/pull/147 (which can be closed as well)