### PR TITLE
Pass pubkey for coinbase

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -80,7 +80,7 @@ fn mine_empty_chain() {
 	for n in 1..4 {
 		let prev = chain.head_header().unwrap();
 		let pk = keychain.derive_pubkey(n as u32).unwrap();
-		let mut b = core::core::Block::new(&prev, vec![], &keychain, pk).unwrap();
+		let mut b = core::core::Block::new(&prev, vec![], &keychain, &pk).unwrap();
 		b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 		let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
@@ -251,7 +251,7 @@ fn prepare_block_nosum(prev: &BlockHeader, diff: u64) -> Block {
 	let keychain = Keychain::from_random_seed().unwrap();
 	let pubkey = keychain.derive_pubkey(1).unwrap();
 
-	let mut b = core::core::Block::new(prev, vec![], &keychain, pubkey).unwrap();
+	let mut b = core::core::Block::new(prev, vec![], &keychain, &pubkey).unwrap();
 	b.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 	b.header.total_difficulty = Difficulty::from_num(diff);
 	b

--- a/chain/tests/store_indices.rs
+++ b/chain/tests/store_indices.rs
@@ -39,7 +39,7 @@ fn test_various_store_indices() {
 
 	let chain_store = &chain::store::ChainKVStore::new(".grin".to_string()).unwrap() as &ChainStore;
 
-	let block = Block::new(&BlockHeader::default(), vec![], &keychain, pubkey).unwrap();
+	let block = Block::new(&BlockHeader::default(), vec![], &keychain, &pubkey).unwrap();
 	let commit = block.outputs[0].commitment();
 	let block_hash = block.hash();
 

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -109,8 +109,7 @@ fn test_coinbase_maturity() {
 		&keychain,
 	).unwrap();
 
-	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, &pk3)
-		.unwrap();
+	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, &pk3).unwrap();
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();

--- a/chain/tests/test_coinbase_maturity.rs
+++ b/chain/tests/test_coinbase_maturity.rs
@@ -76,7 +76,7 @@ fn test_coinbase_maturity() {
 	let pk3 = keychain.derive_pubkey(3).unwrap();
 	let pk4 = keychain.derive_pubkey(4).unwrap();
 
-	let mut block = core::core::Block::new(&prev, vec![], &keychain, pk1.clone()).unwrap();
+	let mut block = core::core::Block::new(&prev, vec![], &keychain, &pk1).unwrap();
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 	let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
@@ -109,7 +109,7 @@ fn test_coinbase_maturity() {
 		&keychain,
 	).unwrap();
 
-	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, pk3.clone())
+	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, &pk3)
 		.unwrap();
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
@@ -138,7 +138,7 @@ fn test_coinbase_maturity() {
 		let keychain = Keychain::from_random_seed().unwrap();
 		let pk = keychain.derive_pubkey(1).unwrap();
 
-		let mut block = core::core::Block::new(&prev, vec![], &keychain, pk).unwrap();
+		let mut block = core::core::Block::new(&prev, vec![], &keychain, &pk).unwrap();
 		block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 
 		let difficulty = consensus::next_difficulty(chain.difficulty_iter()).unwrap();
@@ -157,7 +157,7 @@ fn test_coinbase_maturity() {
 
 	let prev = chain.head_header().unwrap();
 
-	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, pk4).unwrap();
+	let mut block = core::core::Block::new(&prev, vec![&coinbase_txn], &keychain, &pk4).unwrap();
 
 	block.header.timestamp = prev.timestamp + time::Duration::seconds(60);
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -533,7 +533,7 @@ mod test {
 	// header
 	fn new_block(txs: Vec<&Transaction>, keychain: &Keychain) -> Block {
 		let pubkey = keychain.derive_pubkey(1).unwrap();
-		Block::new(&BlockHeader::default(), txs, keychain, pubkey).unwrap()
+		Block::new(&BlockHeader::default(), txs, keychain, &pubkey).unwrap()
 	}
 
 	// utility producing a transaction that spends an output with the provided

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -465,11 +465,18 @@ impl Block {
 	// * That the sum of blinding factors for all coinbase-marked outputs match
 	//   the coinbase-marked kernels.
 	fn verify_coinbase(&self, secp: &Secp256k1) -> Result<(), Error> {
-		let cb_outs = filter_map_vec!(self.outputs, |out| {
-			if out.features.contains(COINBASE_OUTPUT) { Some(out.commitment()) } else { None }
+		let cb_outs = filter_map_vec!(self.outputs, |out| if out.features.contains(
+			COINBASE_OUTPUT,
+		)
+		{
+			Some(out.commitment())
+		} else {
+			None
 		});
-		let cb_kerns = filter_map_vec!(self.kernels, |k| {
-			if k.features.contains(COINBASE_KERNEL) { Some(k.excess) } else { None }
+		let cb_kerns = filter_map_vec!(self.kernels, |k| if k.features.contains(COINBASE_KERNEL) {
+			Some(k.excess)
+		} else {
+			None
 		});
 
 		let over_commit = secp.commit_value(reward(self.total_fees()))?;

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -265,7 +265,7 @@ impl Block {
 		prev: &BlockHeader,
 		txs: Vec<&Transaction>,
 		keychain: &keychain::Keychain,
-		pubkey: keychain::Identifier,
+		pubkey: &keychain::Identifier,
 	) -> Result<Block, keychain::Error> {
 
 		let fees = txs.iter().map(|tx| tx.fee).sum();
@@ -486,16 +486,15 @@ impl Block {
 	/// reward.
 	pub fn reward_output(
 		keychain: &keychain::Keychain,
-		pubkey: keychain::Identifier,
+		pubkey: &keychain::Identifier,
 		fees: u64,
 	) -> Result<(Output, TxKernel), keychain::Error> {
-
 		let secp = keychain.secp();
 
-		let commit = keychain.commit(reward(fees), &pubkey)?;
+		let commit = keychain.commit(reward(fees), pubkey)?;
 		// let switch_commit = keychain.switch_commit(pubkey)?;
 		let msg = secp::pedersen::ProofMessage::empty();
-		let rproof = keychain.range_proof(reward(fees), &pubkey, commit, msg)?;
+		let rproof = keychain.range_proof(reward(fees), pubkey, commit, msg)?;
 
 		let output = Output {
 			features: COINBASE_OUTPUT,

--- a/core/src/core/mod.rs
+++ b/core/src/core/mod.rs
@@ -329,7 +329,7 @@ mod test {
 		let keychain = new_keychain();
 		let pubkey = keychain.derive_pubkey(1).unwrap();
 
-		let b = Block::new(&BlockHeader::default(), vec![], &keychain, pubkey).unwrap();
+		let b = Block::new(&BlockHeader::default(), vec![], &keychain, &pubkey).unwrap();
 		b.compact().validate(&keychain.secp()).unwrap();
 	}
 
@@ -345,7 +345,7 @@ mod test {
 		let mut tx1 = tx2i1o();
 		tx1.verify_sig(keychain.secp()).unwrap();
 
-		let b = Block::new(&BlockHeader::default(), vec![&mut tx1], &keychain, pubkey).unwrap();
+		let b = Block::new(&BlockHeader::default(), vec![&mut tx1], &keychain, &pubkey).unwrap();
 		b.compact().validate(keychain.secp()).unwrap();
 	}
 
@@ -360,7 +360,7 @@ mod test {
 		let mut tx2 = tx1i1o();
 		tx2.verify_sig(keychain.secp()).unwrap();
 
-		let b = Block::new(&BlockHeader::default(), vec![&mut tx1, &mut tx2], &keychain, pubkey).unwrap();
+		let b = Block::new(&BlockHeader::default(), vec![&mut tx1, &mut tx2], &keychain, &pubkey).unwrap();
 		b.validate(keychain.secp()).unwrap();
 	}
 

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -22,6 +22,7 @@
 use std::{error, fmt, cmp};
 use std::io::{self, Write, Read};
 use byteorder::{ByteOrder, ReadBytesExt, BigEndian};
+use keychain::Identifier;
 use secp::pedersen::Commitment;
 use secp::pedersen::RangeProof;
 use secp::constants::PEDERSEN_COMMITMENT_SIZE;
@@ -285,6 +286,19 @@ impl Writeable for Commitment {
 	}
 }
 
+impl Writeable for Identifier {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
+		writer.write_fixed_bytes(self)
+	}
+}
+
+impl Readable for Identifier {
+	fn read(reader: &mut Reader) -> Result<Identifier, Error> {
+		let bytes = reader.read_fixed_bytes(20)?;
+		Ok(Identifier::from_bytes(&bytes))
+	}
+}
+
 impl Writeable for RangeProof {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), Error> {
 		writer.write_fixed_bytes(self)
@@ -509,5 +523,10 @@ impl AsFixedBytes for ::secp::Signature {
 impl AsFixedBytes for ::secp::pedersen::Commitment {
 	fn len(&self) -> usize {
 		return PEDERSEN_COMMITMENT_SIZE;
+	}
+}
+impl AsFixedBytes for ::keychain::Identifier {
+	fn len(&self) -> usize {
+		return 20;
 	}
 }

--- a/keychain/Cargo.toml
+++ b/keychain/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.1.0"
 authors = ["Antioch Peverell"]
 
 [dependencies]
-byteorder = "1"
+byteorder = "~1"
 blake2-rfc = "~0.2.17"
 rand = "~0.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
+serde_json = "~1.0.3"
 grin_util = { path = "../util" }
 secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }

--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -90,15 +90,18 @@ impl Identifier {
 	pub fn to_hex(&self) -> String {
 		self.0.clone()
 	}
+
+	pub fn fingerprint(&self) -> Fingerprint {
+		let hex = &self.0[0..8];
+		Fingerprint(String::from(hex))
+	}
 }
 
-impl ::std::fmt::Debug for Identifier {
-	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		try!(write!(f, "{}(", stringify!(Identifier)));
-		for i in self.0.iter().cloned() {
-			try!(write!(f, "{:02x}", i));
-		}
-		write!(f, ")")
+/// TODO - this is needed for our ser stuff
+/// TODO - which suggests we *do* need to store this as bytes - to investigate
+impl AsRef<[u8]> for Identifier {
+	fn as_ref(&self) -> &[u8] {
+		&self.0.as_ref()
 	}
 }
 

--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -15,6 +15,8 @@
 use std::{error, fmt};
 use std::cmp::min;
 
+use serde::{de, ser};
+
 use byteorder::{ByteOrder, BigEndian};
 use blake2::blake2b::blake2b;
 use secp::Secp256k1;
@@ -75,8 +77,45 @@ impl fmt::Display for Fingerprint {
 	}
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Identifier(String);
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Identifier([u8; 20]);
+
+impl ser::Serialize for Identifier {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: ser::Serializer,
+	{
+		serializer.serialize_str(&self.to_hex())
+	}
+}
+
+impl<'de> de::Deserialize<'de> for Identifier {
+	fn deserialize<D>(deserializer: D) -> Result<Identifier, D::Error>
+	where
+		D: de::Deserializer<'de>,
+	{
+		deserializer.deserialize_u64(IdentifierVisitor)
+	}
+}
+
+struct IdentifierVisitor;
+
+impl<'de> de::Visitor<'de> for IdentifierVisitor {
+	type Value = Identifier;
+
+	fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+		formatter.write_str("an identifier")
+	}
+
+	fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+	where
+		E: de::Error,
+	{
+		// TODO - error handling here
+		let identifier = Identifier::from_hex(s).unwrap();
+		Ok(identifier)
+	}
+}
 
 impl Identifier {
 	pub fn from_bytes(bytes: &[u8]) -> Identifier {
@@ -84,24 +123,37 @@ impl Identifier {
 		for i in 0..min(20, bytes.len()) {
 			identifier[i] = bytes[i];
 		}
-		Identifier(util::to_hex(identifier.to_vec()))
+		Identifier(identifier)
+	}
+
+	fn from_hex(hex: &str) -> Result<Identifier, Error> {
+		// TODO - error handling, don't unwrap here
+		let bytes = util::from_hex(hex.to_string()).unwrap();
+		Ok(Identifier::from_bytes(&bytes))
 	}
 
 	pub fn to_hex(&self) -> String {
-		self.0.clone()
+		util::to_hex(self.0.to_vec())
 	}
 
 	pub fn fingerprint(&self) -> Fingerprint {
-		let hex = &self.0[0..8];
-		Fingerprint(String::from(hex))
+		Fingerprint::from_bytes(&self.0)
 	}
 }
 
-/// TODO - this is needed for our ser stuff
-/// TODO - which suggests we *do* need to store this as bytes - to investigate
 impl AsRef<[u8]> for Identifier {
 	fn as_ref(&self) -> &[u8] {
 		&self.0.as_ref()
+	}
+}
+
+impl ::std::fmt::Debug for Identifier {
+	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+		try!(write!(f, "{}(", stringify!(Identifier)));
+		for i in self.0.iter().cloned() {
+			try!(write!(f, "{:02x}", i));
+		}
+		write!(f, ")")
 	}
 }
 
@@ -216,6 +268,8 @@ impl ExtendedKey {
 
 #[cfg(test)]
 mod test {
+	use serde_json;
+
 	use secp::Secp256k1;
 	use secp::key::SecretKey;
 	use super::{ExtendedKey, Fingerprint, Identifier};
@@ -223,6 +277,29 @@ mod test {
 
 	fn from_hex(hex_str: &str) -> Vec<u8> {
 		util::from_hex(hex_str.to_string()).unwrap()
+	}
+
+	#[test]
+	fn test_identifier_json_ser_deser() {
+		let hex = "942b6c0bd43bdcb24f3edfe7fadbc77054ecc4f2";
+		let identifier = Identifier::from_hex(hex).unwrap();
+
+		#[derive(Debug, Serialize, Deserialize, PartialEq)]
+		struct HasAnIdentifier {
+			identifier: Identifier,
+		}
+
+		let has_an_identifier = HasAnIdentifier { identifier };
+
+		let json = serde_json::to_string(&has_an_identifier).unwrap();
+
+		assert_eq!(
+			json,
+			"{\"identifier\":\"942b6c0bd43bdcb24f3edfe7fadbc77054ecc4f2\"}"
+		);
+
+		let deserialized: HasAnIdentifier = serde_json::from_str(&json).unwrap();
+		assert_eq!(deserialized, has_an_identifier);
 	}
 
 	#[test]

--- a/keychain/src/extkey.rs
+++ b/keychain/src/extkey.rs
@@ -79,7 +79,7 @@ impl fmt::Display for Fingerprint {
 pub struct Identifier(String);
 
 impl Identifier {
-	fn from_bytes(bytes: &[u8]) -> Identifier {
+	pub fn from_bytes(bytes: &[u8]) -> Identifier {
 		let mut identifier = [0; 20];
 		for i in 0..min(20, bytes.len()) {
 			identifier[i] = bytes[i];
@@ -90,10 +90,15 @@ impl Identifier {
 	pub fn to_hex(&self) -> String {
 		self.0.clone()
 	}
+}
 
-	pub fn fingerprint(&self) -> Fingerprint {
-		let hex = &self.0[0..8];
-		Fingerprint(String::from(hex))
+impl ::std::fmt::Debug for Identifier {
+	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+		try!(write!(f, "{}(", stringify!(Identifier)));
+		for i in self.0.iter().cloned() {
+			try!(write!(f, "{:02x}", i));
+		}
+		write!(f, ")")
 	}
 }
 

--- a/keychain/src/lib.rs
+++ b/keychain/src/lib.rs
@@ -22,6 +22,7 @@ extern crate grin_util as util;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 
 mod blind;
 mod extkey;

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -908,7 +908,7 @@ mod tests {
 			&block::BlockHeader::default(),
 			block_transactions,
 			&keychain,
-			pubkey,
+			&pubkey,
 		).unwrap();
 
 		chain_ref.apply_block(&block);
@@ -1007,7 +1007,7 @@ mod tests {
 
 			let keychain = Keychain::from_random_seed().unwrap();
 			let pubkey = keychain.derive_pubkey(1).unwrap();
-			block = block::Block::new(&block::BlockHeader::default(), tx_refs, &keychain, pubkey)
+			block = block::Block::new(&block::BlockHeader::default(), tx_refs, &keychain, &pubkey)
 				.unwrap();
 		}
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -385,7 +385,13 @@ pub enum WalletReceiveRequest {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BlockFees {
 	pub fees: u64,
-	pub derivation: u32,
+	pub pubkey: Option<keychain::Identifier>,
+}
+
+impl BlockFees {
+	pub fn pubkey(&self) -> Option<keychain::Identifier> {
+		self.pubkey.clone()
+	}
 }
 
 /// Response to build a coinbase output.
@@ -393,5 +399,5 @@ pub struct BlockFees {
 pub struct CbData {
 	pub output: String,
 	pub kernel: String,
-	pub derivation: u32,
+	pub pubkey: String,
 }

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -278,6 +278,37 @@ impl WalletData {
 		self.outputs.insert(out.identifier.to_hex(), out.clone());
 	}
 
+	// fn update_output(&mut self, out: OutputData) {
+	// 	if let Some(mut existing) = self.outputs.iter_mut().find(|existing| {
+	// 		existing.fingerprint == out.fingerprint
+	// 			&& existing.n_child == out.n_child
+	// 	}) {
+	// 		existing.update_value(out.value)
+	// 	}
+	// }
+
+	// fn find_existing_by_n_child(&mut self, out: &OutputData) -> Option<OutputData> {
+	// 	self.outputs.iter_mut().find(|existing| {
+	// 		existing.fingerprint == out.fingerprint
+	// 			&& existing.n_child == out.n_child
+	// 	})
+	// }
+
+	// /// Append a new output data, or update if it already exists.
+	// /// TODO - we should track identifier on these outputs (not just n_child)
+	// pub fn append_or_update_output(&mut self, out: OutputData) {
+	// 	let mut existing = self.outputs.iter_mut().find(|existing| {
+	// 		existing.fingerprint == out.fingerprint
+	// 			&& existing.n_child == out.n_child
+	// 	});
+	//
+	//
+	// 	match existing {
+	// 		Some(&mut existing) => existing.update_value(out.value),
+	// 		None => self.append_output(out),
+	// 	}
+	// }
+
 	/// Lock an output data.
 	/// TODO - we should track identifier on these outputs (not just n_child)
 	pub fn lock_output(&mut self, out: &OutputData) {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -272,42 +272,10 @@ impl WalletData {
 	}
 
 	/// Append a new output data to the wallet data.
-	/// TODO - we should check for overwriting here - only really valid for
-	/// unconfirmed coinbase
+	/// TODO - we should check for overwriting here - only really valid for unconfirmed coinbase
 	pub fn add_output(&mut self, out: OutputData) {
 		self.outputs.insert(out.identifier.to_hex(), out.clone());
 	}
-
-	// fn update_output(&mut self, out: OutputData) {
-	// 	if let Some(mut existing) = self.outputs.iter_mut().find(|existing| {
-	// 		existing.fingerprint == out.fingerprint
-	// 			&& existing.n_child == out.n_child
-	// 	}) {
-	// 		existing.update_value(out.value)
-	// 	}
-	// }
-
-	// fn find_existing_by_n_child(&mut self, out: &OutputData) -> Option<OutputData> {
-	// 	self.outputs.iter_mut().find(|existing| {
-	// 		existing.fingerprint == out.fingerprint
-	// 			&& existing.n_child == out.n_child
-	// 	})
-	// }
-
-	// /// Append a new output data, or update if it already exists.
-	// /// TODO - we should track identifier on these outputs (not just n_child)
-	// pub fn append_or_update_output(&mut self, out: OutputData) {
-	// 	let mut existing = self.outputs.iter_mut().find(|existing| {
-	// 		existing.fingerprint == out.fingerprint
-	// 			&& existing.n_child == out.n_child
-	// 	});
-	//
-	//
-	// 	match existing {
-	// 		Some(&mut existing) => existing.update_value(out.value),
-	// 		None => self.append_output(out),
-	// 	}
-	// }
 
 	/// Lock an output data.
 	/// TODO - we should track identifier on these outputs (not just n_child)

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -264,7 +264,7 @@ impl WalletData {
 			Error::WalletData(format!("Could not create {}: {}", data_file_path, e))
 		})?;
 		let res_json = serde_json::to_vec_pretty(self).map_err(|e| {
-			Error::WalletData(format!("Error serializing wallet data."))
+			Error::WalletData(format!("Error serializing wallet data: {}", e))
 		})?;
 		data_file.write_all(res_json.as_slice()).map_err(|e| {
 			Error::WalletData(format!("Error writing {}: {}", data_file_path, e))

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -272,7 +272,8 @@ impl WalletData {
 	}
 
 	/// Append a new output data to the wallet data.
-	/// TODO - we should check for overwriting here - only really valid for unconfirmed coinbase
+	/// TODO - we should check for overwriting here - only really valid for
+	/// unconfirmed coinbase
 	pub fn add_output(&mut self, out: OutputData) {
 		self.outputs.insert(out.identifier.to_hex(), out.clone());
 	}


### PR DESCRIPTION
Building on the wallet changes from #158 we can now pass an `Identifier` to and from the miner, instead of passing the `derivation`.
This allows us to keep `derivation` internal to wallet/keychain.


* Use `[u8; 20]` internally in Identifier so we can be sure we are serializing/deserializing in `ser` correctly via `Readable/Writeable`.
* Add serde_json `Serialize/Deserialize/Visitor` for `Identifier` so wallet.dat is clean and the api calls between miner and wallet serialize identifiers in a sane way (as hex encoded strings).
* Add some tests for json serialization/deserialization.

Example `block_fees` in the miner -

```
 BlockFees { fees: 0, pubkey: Some(Identifier(4cc0d030afeaa6413e7862dcf0b924fbf802fd0f)) }
```

Example wallet file -

```
cat wallet.dat
{
  "outputs": {
    "ac6a91ce7564bd4be32a485c4737519c2f5d2bf4": {
      "fingerprint": "bee24629",
      "identifier": "ac6a91ce7564bd4be32a485c4737519c2f5d2bf4",
      "n_child": 6,
      "value": 1000000005,
      "status": "Immature",
      "height": 6,
      "lock_height": 9
    },
    "6040547de5ffa4e01b29d47b336a8c31050e3dc8": {
      "fingerprint": "bee24629",
      "identifier": "6040547de5ffa4e01b29d47b336a8c31050e3dc8",
      "n_child": 3,
      "value": 1000000000,
      "status": "Immature",
      "height": 3,
      "lock_height": 6
    },
    ...
}
```

`wallet info` after spending an output - 

```
Outputs - 
identifier, height, lock_height, status, value
----------------------------------
fd997546..., 1, 4, Spent, 1000000000
15d2f09b..., 2, 5, Unspent, 1000000000
6040547d..., 3, 6, Immature, 1000000000
8d3f2247..., 4, 7, Immature, 1000000000
abfb3af7..., 5, 8, Immature, 1000000000
ac6a91ce..., 6, 9, Immature, 1000000005
3177752d..., 6, 0, Unspent, 995000000
712e0ddc..., 6, 0, Unspent, 4999990
4cc0d030..., 0, 0, Unconfirmed, 1000000000
```
