### PR TITLE
fail deserialization if inputs or outputs are not sorted for txs

### DIFF
--- a/chain/tests/mine_simple_chain.rs
+++ b/chain/tests/mine_simple_chain.rs
@@ -59,7 +59,6 @@ fn setup(dir_name: &str) -> Chain {
 #[test]
 fn mine_empty_chain() {
 	let chain = setup(".grin");
-
 	let keychain = Keychain::from_random_seed().unwrap();
 
 	// mine and add a few blocks

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -21,6 +21,7 @@
 
 use std::fmt;
 
+use ser;
 use core::target::Difficulty;
 
 /// The block subsidy amount
@@ -204,6 +205,12 @@ where
 	Ok(
 		diff_avg * Difficulty::from_num(BLOCK_TIME_WINDOW) / Difficulty::from_num(adj_ts),
 	)
+}
+
+/// Consensus rule that collections of items are sorted lexicographically over the wire.
+pub trait VerifySortOrder<T> {
+	/// Verify a collection of items is sorted as required.
+	fn verify_sort_order(&self) -> Result<(), ser::Error>;
 }
 
 #[cfg(test)]

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -77,8 +77,7 @@ pub const MAX_BLOCK_WEIGHT: usize = 80_000;
 
 /// Whether a block exceeds the maximum acceptable weight
 pub fn exceeds_weight(input_len: usize, output_len: usize, kernel_len: usize) -> bool {
-	input_len * BLOCK_INPUT_WEIGHT +
-		output_len * BLOCK_OUTPUT_WEIGHT +
+	input_len * BLOCK_INPUT_WEIGHT + output_len * BLOCK_OUTPUT_WEIGHT +
 		kernel_len * BLOCK_KERNEL_WEIGHT > MAX_BLOCK_WEIGHT
 }
 

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -20,10 +20,10 @@ use std::collections::HashSet;
 
 use core::Committed;
 use core::{Input, Output, Proof, TxKernel, Transaction, COINBASE_KERNEL, COINBASE_OUTPUT};
-use consensus::{MINIMUM_DIFFICULTY, REWARD, reward, exceeds_weight, VerifySortOrder};
+use consensus::{MINIMUM_DIFFICULTY, REWARD, reward, exceeds_weight};
 use core::hash::{Hash, Hashed, ZERO_HASH};
 use core::target::Difficulty;
-use ser::{self, Readable, Reader, Writeable, Writer, WriteableSorted};
+use ser::{self, Readable, Reader, Writeable, Writer, WriteableSorted, read_and_verify_sorted};
 use global;
 use keychain;
 
@@ -189,11 +189,11 @@ impl Writeable for Block {
 				[write_u64, self.kernels.len() as u64]
 			);
 
-			// Consensus rule that everything is sorted in lexicographical order on the wire.
 			let mut inputs = self.inputs.clone();
 			let mut outputs = self.outputs.clone();
 			let mut kernels = self.kernels.clone();
 
+			// Consensus rule that everything is sorted in lexicographical order on the wire.
 			try!(inputs.write_sorted(writer));
 			try!(outputs.write_sorted(writer));
 			try!(kernels.write_sorted(writer));
@@ -208,18 +208,12 @@ impl Readable for Block {
 	fn read(reader: &mut Reader) -> Result<Block, ser::Error> {
 		let header = try!(BlockHeader::read(reader));
 
-		let (input_len, output_len, proof_len) =
+		let (input_len, output_len, kernel_len) =
 			ser_multiread!(reader, read_u64, read_u64, read_u64);
 
-		let inputs: Vec<_> = try!((0..input_len).map(|_| Input::read(reader)).collect());
-		let outputs: Vec<_> = try!((0..output_len).map(|_| Output::read(reader)).collect());
-		let kernels: Vec<_> = try!((0..proof_len).map(|_| TxKernel::read(reader)).collect());
-
-		// Consensus rule that everything is sorted lexicographically to avoid
-		// leaking any information through specific ordering of items.
-		inputs.verify_sort_order()?;
-		outputs.verify_sort_order()?;
-		kernels.verify_sort_order()?;
+		let inputs = read_and_verify_sorted(reader, input_len)?;
+		let outputs = read_and_verify_sorted(reader, output_len)?;
+		let kernels = read_and_verify_sorted(reader, kernel_len)?;
 
 		Ok(Block {
 			header: header,
@@ -402,9 +396,6 @@ impl Block {
 
 		let mut all_kernels = self.kernels.clone();
 		all_kernels.append(&mut other.kernels.clone());
-
-		// all_inputs.sort_by_key(|inp| inp.hash());
-		// all_outputs.sort_by_key(|out| out.hash());
 
 		Block {
 			// compact will fix the merkle tree

--- a/core/src/core/block.rs
+++ b/core/src/core/block.rs
@@ -297,7 +297,7 @@ impl Block {
 		// build vectors with all inputs and all outputs, ordering them by hash
 		// needs to be a fold so we don't end up with a vector of vectors and we
 		// want to fully own the refs (not just a pointer like flat_map).
-		let mut inputs = txs.iter().fold(vec![], |mut acc, ref tx| {
+		let inputs = txs.iter().fold(vec![], |mut acc, ref tx| {
 			let mut inputs = tx.inputs.clone();
 			acc.append(&mut inputs);
 			acc
@@ -308,9 +308,6 @@ impl Block {
 			acc
 		});
 		outputs.push(reward_out);
-
-		inputs.sort_by_key(|inp| inp.hash());
-		outputs.sort_by_key(|out| out.hash());
 
 		// calculate the overall Merkle tree and fees
 
@@ -406,8 +403,8 @@ impl Block {
 		let mut all_kernels = self.kernels.clone();
 		all_kernels.append(&mut other.kernels.clone());
 
-		all_inputs.sort_by_key(|inp| inp.hash());
-		all_outputs.sort_by_key(|out| out.hash());
+		// all_inputs.sort_by_key(|inp| inp.hash());
+		// all_outputs.sort_by_key(|out| out.hash());
 
 		Block {
 			// compact will fix the merkle tree

--- a/core/src/ser.rs
+++ b/core/src/ser.rs
@@ -43,6 +43,8 @@ pub enum Error {
 	CorruptedData,
 	/// When asked to read too much data
 	TooLargeReadErr,
+	/// Something was not sorted when consensus rules requires it to be sorted
+	BadlySorted,
 }
 
 impl From<io::Error> for Error {
@@ -61,6 +63,7 @@ impl fmt::Display for Error {
 			} => write!(f, "expected {:?}, got {:?}", e, r),
 			Error::CorruptedData => f.write_str("corrupted data"),
 			Error::TooLargeReadErr => f.write_str("too large read"),
+			Error::BadlySorted => f.write_str("badly sorted data"),
 		}
 	}
 }
@@ -82,6 +85,7 @@ impl error::Error for Error {
 			} => "unexpected data",
 			Error::CorruptedData => "corrupted data",
 			Error::TooLargeReadErr => "too large read",
+			Error::BadlySorted => "badly sorted data",
 		}
 	}
 }


### PR DESCRIPTION
Added `VerifySortOrder` trait and a `read_and_verify_sorted` function so we can call the following during deserialization - 

```
let inputs = read_and_verify_sorted(reader, input_len)?;
```

`VerifySortOrder` iterates over `window(2)` over the collection so we can efficiently compare each value with the previous. If previous is ever larger then we are not sorted and we fail.

Added `WriteableSorted` trait so we can call the following during serialization -

```
try!(inputs.write_sorted(writer));
```


-----------

This PR addresses #168 and adds a consensus rule to ensure input and outputs are sorted for txs. Similarly inputs, outputs and kernels are sorted for blocks.

- fail in deserialization if inputs or outputs are not sorted for txs
- fail in deserialization if inputs, outputs or kernels are not sorted for blocks
- make sure we sort them before serialization
