### PR TITLE
tweaks to logging configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ daemonize = "^0.2.3"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 serde_json = "~1.0.2"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 
 # TODO - once "patch" is available we should be able to clean up the workspace dependencies
 # [patch.crate-io]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,7 +12,7 @@ grin_store = { path = "../store" }
 grin_util = { path = "../util" }
 secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 hyper = "~0.10.6"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 iron = "~0.5.1"
 router = "~0.5.1"
 serde = "~1.0.8"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 [dependencies]
 bitflags = "^0.7.0"
 byteorder = "^0.5"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 serde = "~1.0.8"
 serde_derive = "~1.0.8"
 time = "^0.1"

--- a/doc/build.md
+++ b/doc/build.md
@@ -102,12 +102,12 @@ Before running your mining server, a wallet server needs to be set up and listen
 
     node1$ grin wallet -p "password" receive
 
-This will create a wallet server listening on the default port 13415 with the password "password". Next, in another terminal window in the 'node1' directory, run a full mining node with the following command:
+This will create a wallet server listening on the default port 13416 with the password "password". Next, in another terminal window in the 'node1' directory, run a full mining node with the following command:
 
     node1$ grin server -m run
 
 This creates a new .grin database directory in the current directory, and begins mining new blocks (with no transactions, for now). Note this starts two services listening on two default ports, 
-port 13414 for the peer-to-peer (P2P) service which keeps all nodes synchronised, and 13415 for the Rest API service used to verify transactions and post new transactions to the pool (for example). These ports can be configured via command line switches, or via a grin.toml file in the working directory.
+port 13414 for the peer-to-peer (P2P) service which keeps all nodes synchronised, and 13413 for the Rest API service used to verify transactions and post new transactions to the pool (for example). These ports can be configured via command line switches, or via a grin.toml file in the working directory.
 
 Let the mining server find a few blocks, then stop (just ctrl-c) the mining server and the wallet server. You'll notice grin has created a database directory (.grin) in which the blockchain and peer data is stored. There should also be a wallet.dat file in the current directory, which contains a few coinbase mining rewards created each time the server mines a new block.
 

--- a/grin.toml
+++ b/grin.toml
@@ -86,7 +86,7 @@ log_file_append = true
 
 #flag whether mining is enabled
 
-enable_mining = true
+enable_mining = false
 
 #Whether to use cuckoo-miner,  and related parameters
 
@@ -115,7 +115,7 @@ wallet_receiver_url = "http://127.0.0.1:13416"
 
 #whether to ignore the reward (mostly for testing)
 
-burn_reward = true
+burn_reward = false
 
 #testing value, optional
 #slow_down_in_millis = 30

--- a/grin.toml
+++ b/grin.toml
@@ -86,7 +86,7 @@ log_file_append = true
 
 #flag whether mining is enabled
 
-enable_mining = false
+enable_mining = true
 
 #Whether to use cuckoo-miner,  and related parameters
 
@@ -115,7 +115,7 @@ wallet_receiver_url = "http://127.0.0.1:13416"
 
 #whether to ignore the reward (mostly for testing)
 
-burn_reward = false
+burn_reward = true
 
 #testing value, optional
 #slow_down_in_millis = 30

--- a/grin/Cargo.toml
+++ b/grin/Cargo.toml
@@ -20,7 +20,7 @@ secp256k1zkp = { git = "https://github.com/mimblewimble/rust-secp256k1-zkp" }
 futures = "^0.1.15"
 futures-cpupool = "^0.1.3"
 hyper = { git = "https://github.com/hyperium/hyper" }
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 time = "^0.1"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,7 +8,7 @@ workspace = ".."
 bitflags = "^0.7.0"
 byteorder = "^0.5"
 futures = "^0.1.15"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 net2 = "0.2.0"
 rand = "^0.3"
 serde = "~1.0.8"

--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -8,7 +8,7 @@ workspace = ".."
 blake2-rfc = "~0.2.17"
 rand = "^0.3"
 time = "^0.1"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 lazy_static = "~0.2.8"
 serde = "~1.0.8"
 serde_derive = "~1.0.8"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -7,7 +7,7 @@ workspace = ".."
 [dependencies]
 byteorder = "^0.5"
 env_logger="^0.3.5"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 libc = "^0.2"
 memmap = { git = "https://github.com/danburkert/memmap-rs" }
 rocksdb = "^0.7.0"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Ignotus Peverell <igno.peverell@protonmail.com>",
 workspace = ".."
 
 [dependencies]
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "^2.2.0"
 slog-async = "^2.1.0"
 lazy_static = "~0.2.8"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
 [dependencies]
 
 byteorder = "1"
-slog = "^2.0.12"
+slog = { version = "^2.0.12", features = ["max_level_trace", "release_max_level_trace"] }
 rand = "^0.3"
 blake2-rfc = "~0.2.17"
 serde = "~1.0.8"


### PR DESCRIPTION
Tweaks to logging configuration, and log won't output at all unless a call to init_logging has been explicitly made (so logging isn't automatically output during cargo test, however the option to do so is there). Will also output according to settings in grin.toml regardless of whether under a release or debug build, including trace statements. Note the following from the slog documentation:



slog by default removes at compile time trace and debug level statements in release builds, and trace level records in debug builds. This makes trace and debug level logging records practically free, which should encourage using them freely. If you want to enable trace/debug messages or raise the compile time logging level limit, use the following in your Cargo.toml:

slog = { version = "1.0.0", features = ["max_level_trace", "release_max_level_warn"] }