### PR TITLE
refactor burn key into key_overrides on keychain

### DIFF
--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -55,14 +55,14 @@ impl Keychain {
 		self.extkey.root_key_id.clone()
 	}
 
-	//
 	// For tests and burn only, associate a key identifier with a known secret key.
 	//
 	pub fn burn_enabled(keychain: &Keychain, burn_key_id: &Identifier) -> Keychain {
 		let mut key_overrides = HashMap::new();
 		key_overrides.insert(
 			burn_key_id.clone(),
-			SecretKey::from_slice(&keychain.secp, &[1; 32]).unwrap());
+			SecretKey::from_slice(&keychain.secp, &[1; 32]).unwrap(),
+		);
 		Keychain {
 			key_overrides: key_overrides,
 			..keychain.clone()
@@ -104,7 +104,9 @@ impl Keychain {
 				return Ok(extkey.key);
 			}
 		}
-		Err(Error::KeyDerivation(format!("cannot find extkey for {:?}", key_id)))
+		Err(Error::KeyDerivation(
+			format!("cannot find extkey for {:?}", key_id),
+		))
 	}
 
 	pub fn commit(&self, amount: u64, key_id: &Identifier) -> Result<Commitment, Error> {
@@ -239,19 +241,25 @@ mod test {
 		let key_id2 = keychain.derive_key_id(2).unwrap();
 
 		// cannot rewind with a different nonce
-		let proof_info = keychain.rewind_range_proof(&key_id2, commit, proof).unwrap();
+		let proof_info = keychain
+			.rewind_range_proof(&key_id2, commit, proof)
+			.unwrap();
 		assert_eq!(proof_info.success, false);
 		assert_eq!(proof_info.value, 0);
 
 		// cannot rewind with a commitment to the same value using a different key
 		let commit2 = keychain.commit(5, &key_id2).unwrap();
-		let proof_info = keychain.rewind_range_proof(&key_id, commit2, proof).unwrap();
+		let proof_info = keychain
+			.rewind_range_proof(&key_id, commit2, proof)
+			.unwrap();
 		assert_eq!(proof_info.success, false);
 		assert_eq!(proof_info.value, 0);
 
 		// cannot rewind with a commitment to a different value
 		let commit3 = keychain.commit(4, &key_id).unwrap();
-		let proof_info = keychain.rewind_range_proof(&key_id, commit3, proof).unwrap();
+		let proof_info = keychain
+			.rewind_range_proof(&key_id, commit3, proof)
+			.unwrap();
 		assert_eq!(proof_info.success, false);
 		assert_eq!(proof_info.value, 0);
 	}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -93,19 +93,13 @@ impl Keychain {
 		Ok(key_id)
 	}
 
-	// TODO - smarter lookups - can we cache key_id/fingerprint -> derivation
-	// number somehow?
 	fn derived_key(&self, key_id: &Identifier) -> Result<SecretKey, Error> {
-		// TODO - is this the cache right here? Do we just lazily populate it in normal use?
 		if let Some(key) = self.key_overrides.get(key_id) {
 			return Ok(*key);
 		}
 
 		for i in 1..10000 {
 			let extkey = self.extkey.derive(&self.secp, i)?;
-
-			// TODO - populate the cache here for every derived key here?
-
 			if extkey.identifier(&self.secp)? == *key_id {
 				return Ok(extkey.key);
 			}

--- a/keychain/src/keychain.rs
+++ b/keychain/src/keychain.rs
@@ -58,9 +58,6 @@ impl Keychain {
 	//
 	// For tests and burn only, associate a key identifier with a known secret key.
 	//
-	// TODO - does this need to be a "known" key? Or can we just generate one randomly
-	// and *really* burn the coins?
-	//
 	pub fn burn_enabled(keychain: &Keychain, burn_key_id: &Identifier) -> Keychain {
 		let mut key_overrides = HashMap::new();
 		key_overrides.insert(

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -325,7 +325,7 @@ fn wallet_command(wallet_args: &ArgMatches) {
 
 	// TODO do something closer to BIP39, eazy solution right now
 	let seed = blake2::blake2b::blake2b(32, &[], hd_seed.as_bytes());
-	let mut keychain = Keychain::from_seed(seed.as_bytes()).expect(
+	let keychain = Keychain::from_seed(seed.as_bytes()).expect(
 		"Failed to initialize keychain from the provided seed.",
 	);
 
@@ -390,7 +390,6 @@ fn wallet_command(wallet_args: &ArgMatches) {
 				.expect("Amount to burn required")
 				.parse()
 				.expect("Could not parse amount as a whole number.");
-			keychain.enable_burn_key = true;
 			wallet::issue_burn_tx(&wallet_config, &keychain, amount).unwrap();
 		}
 		("info", Some(_)) => {

--- a/wallet/src/info.rs
+++ b/wallet/src/info.rs
@@ -24,7 +24,7 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 	let _ = WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
 
 		println!("Outputs - ");
-		println!("key_id, height, lock_height, status, value");
+		println!("key_id, height, lock_height, status, zero_ok, value");
 		println!("----------------------------------");
 
 		let mut outputs = wallet_data
@@ -35,11 +35,12 @@ pub fn show_info(config: &WalletConfig, keychain: &Keychain) {
 		outputs.sort_by_key(|out| out.n_child);
 		for out in outputs {
 			println!(
-				"{}, {}, {}, {:?}, {}",
+				"{}, {}, {}, {:?}, {}, {}",
 				out.key_id,
 				out.height,
 				out.lock_height,
 				out.status,
+				out.zero_ok,
 				out.value
 			);
 		}

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -205,6 +205,7 @@ fn receive_coinbase(config: &WalletConfig,
 			status: OutputStatus::Unconfirmed,
 			height: 0,
 			lock_height: 0,
+			zero_ok: false,
 		});
 
 		debug!(
@@ -279,6 +280,7 @@ fn receive_transaction(
 			status: OutputStatus::Unconfirmed,
 			height: 0,
 			lock_height: 0,
+			zero_ok: false,
 		});
 		debug!(
 			LOGGER,

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -183,8 +183,11 @@ fn receive_coinbase(config: &WalletConfig,
 		let key_id = block_fees.key_id();
 		let (key_id, derivation) = match key_id {
 			Some(key_id) => {
-				let derivation = keychain.derivation_from_key_id(&key_id)?;
-				(key_id.clone(), derivation)
+				if let Some(existing) = wallet_data.get_output(&key_id) {
+					(existing.key_id.clone(), existing.n_child)
+				} else {
+					panic!("should never happen");
+				}
 			},
 			None => {
 				let derivation = wallet_data.next_child(root_key_id.clone());

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -73,12 +73,8 @@ fn build_send_tx(
 
 		// select some suitable outputs to spend from our local wallet
 		let (coins, _) = wallet_data.select(key_id.clone(), u64::max_value());
-		// if change < 0 {
-		// 	return Err(Error::NotEnoughFunds((-change) as u64));
-		// }
 
 		// build transaction skeleton with inputs and change
-		// TODO - inputs_and_change should raise NotEnoughFunds
 		// TODO - should probably also check we are sending enough to cover the fees + non-zero output
 		let mut parts = inputs_and_change(&coins, keychain, key_id, wallet_data, amount)?;
 

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -161,19 +161,19 @@ fn inputs_and_change(
 	let change_key = keychain.derive_key_id(change_derivation)?;
 	parts.push(build::output(change, change_key.clone()));
 
-	// we got that far, time to start tracking the new output
-	// and lock the outputs used
+	// we got that far, time to start tracking the output representing our change
 	wallet_data.add_output(OutputData {
 		root_key_id: root_key_id.clone(),
 		key_id: change_key.clone(),
 		n_child: change_derivation,
 		value: change as u64,
-		status: OutputStatus::UnconfirmedChange,
+		status: OutputStatus::Unconfirmed,
 		height: 0,
 		lock_height: 0,
+		zero_ok: true,
 	});
 
-	// lock the ouputs we're spending
+	// now lock the ouputs we're spending so we avoid accidental double spend attempt
 	for coin in coins {
 		wallet_data.lock_output(coin);
 	}

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -72,12 +72,14 @@ fn build_send_tx(
 	WalletData::with_wallet(&config.data_file_dir, |wallet_data| {
 
 		// select some suitable outputs to spend from our local wallet
-		let (coins, change) = wallet_data.select(key_id.clone(), amount);
-		if change < 0 {
-			return Err(Error::NotEnoughFunds((-change) as u64));
-		}
+		let (coins, _) = wallet_data.select(key_id.clone(), u64::max_value());
+		// if change < 0 {
+		// 	return Err(Error::NotEnoughFunds((-change) as u64));
+		// }
 
 		// build transaction skeleton with inputs and change
+		// TODO - inputs_and_change should raise NotEnoughFunds
+		// TODO - should probably also check we are sending enough to cover the fees + non-zero output
 		let mut parts = inputs_and_change(&coins, keychain, key_id, wallet_data, amount)?;
 
 		// This is more proof of concept than anything but here we set a
@@ -92,7 +94,7 @@ fn build_send_tx(
 }
 
 pub fn issue_burn_tx(config: &WalletConfig, keychain: &Keychain, amount: u64) -> Result<(), Error> {
-	let keychain = &Keychain::burn_enabled(keychain);
+	let keychain = &Keychain::burn_enabled(keychain, &Identifier::zero());
 
 	let _ = checker::refresh_outputs(config, keychain);
 

--- a/wallet/src/sender.rs
+++ b/wallet/src/sender.rs
@@ -170,7 +170,7 @@ fn inputs_and_change(
 		key_id: change_key.clone(),
 		n_child: change_derivation,
 		value: change as u64,
-		status: OutputStatus::Unconfirmed,
+		status: OutputStatus::UnconfirmedChange,
 		height: 0,
 		lock_height: 0,
 	});

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -131,6 +131,7 @@ impl Default for WalletConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum OutputStatus {
 	Unconfirmed,
+	UnconfirmedChange,
 	Unspent,
 	Immature,
 	Locked,
@@ -141,6 +142,7 @@ impl fmt::Display for OutputStatus {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			OutputStatus::Unconfirmed => write!(f, "Unconfirmed"),
+			OutputStatus::UnconfirmedChange => write!(f, "UnconfirmedChange"),
 			OutputStatus::Unspent => write!(f, "Unspent"),
 			OutputStatus::Immature => write!(f, "Immature"),
 			OutputStatus::Locked => write!(f, "Locked"),

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -309,6 +309,10 @@ impl WalletData {
 		}
 	}
 
+	pub fn get_output(&self, key_id: &keychain::Identifier) -> Option<&OutputData> {
+		self.outputs.get(&key_id.to_hex())
+	}
+
 	/// Select a subset of unspent outputs to spend in a transaction
 	/// transferring the provided amount.
 	pub fn select(&self, root_key_id: keychain::Identifier, amount: u64) -> (Vec<OutputData>, i64) {
@@ -318,7 +322,9 @@ impl WalletData {
 		// TODO very naive impl for now - definitely better coin selection
 		// algos available
 		for out in self.outputs.values() {
-			if out.status == OutputStatus::Unspent && out.root_key_id == root_key_id {
+			if [OutputStatus::Unspent, OutputStatus::UnconfirmedChange].contains(&out.status)
+				&& out.root_key_id == root_key_id
+			{
 				to_spend.push(out.clone());
 				input_total += out.value;
 				if input_total >= amount {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -313,6 +313,9 @@ impl WalletData {
 		self.outputs.get(&key_id.to_hex())
 	}
 
+	///
+	/// TODO - this can be simplified significantly if we spend all spendable coins every time
+	///
 	/// Select a subset of unspent outputs to spend in a transaction
 	/// transferring the provided amount.
 	pub fn select(&self, root_key_id: keychain::Identifier, amount: u64) -> (Vec<OutputData>, i64) {

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -313,9 +313,6 @@ impl WalletData {
 		self.outputs.get(&key_id.to_hex())
 	}
 
-	///
-	/// TODO - this can be simplified significantly if we spend all spendable coins every time
-	///
 	/// Select a subset of unspent outputs to spend in a transaction
 	/// transferring the provided amount.
 	pub fn select(&self, root_key_id: keychain::Identifier, amount: u64) -> (Vec<OutputData>, i64) {
@@ -325,7 +322,7 @@ impl WalletData {
 		for out in self.outputs.values() {
 			if out.root_key_id == root_key_id
 				&& (out.status == OutputStatus::Unspent)
-					// TODO - following line will allow zero confirmation spends on change outputs
+					// the following will let us spend zero confirmation change outputs
 					// || (out.status == OutputStatus::Unconfirmed && out.zero_ok))
 			{
 				to_spend.push(out.clone());


### PR DESCRIPTION
Possible approach to make the burn key implementation more flexible - 

* introduce `burn_enabled` on Keychain to take a keychain and add a key override
* introduce a map of identifer->secret_key overrides to keychain
* key overrides on a keychain take precedence (if present)
* fix fee calc in `issue_burn_tx` (which I broke when fixing fee calc in `inputs_and_change` previously...)

Right now we only use key_overrides within `issue_burn_tx` and we throw the "burner" keychain away when we are finished. We don't touch the original keychain so it is safe to subsequent use.

