### PR TITLE
update_roots on pool to keep it consistent after reconciliation

### DIFF
--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -940,6 +940,10 @@ mod tests {
 		{
 			let read_pool = pool.write().unwrap();
 			assert_eq!(read_pool.pool.len_vertices(), 1);
+
+			//
+			// this fails - the tx is not in the list of roots (but it should be)
+			//
 			assert_eq!(read_pool.pool.len_roots(), 1);
 		}
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -934,16 +934,12 @@ mod tests {
 			assert_eq!(evicted_transactions.len(), 1);
 		}
 
-		// check the pool looks as it should
+		// check the pool is consistent after reconciling the block
 		// we should have 1 tx in the pool and it should
 		// be in the list of roots (will not be mineable otherwise)
 		{
 			let read_pool = pool.write().unwrap();
 			assert_eq!(read_pool.pool.len_vertices(), 1);
-
-			//
-			// this fails - the tx is not in the list of roots (but it should be)
-			//
 			assert_eq!(read_pool.pool.len_roots(), 1);
 		}
 	}

--- a/pool/src/pool.rs
+++ b/pool/src/pool.rs
@@ -547,6 +547,11 @@ where
 
 			removed_txs.push(removed_tx);
 		}
+
+		// final step is to update the pool to reflect the new set of roots
+		// a tx that was non-root may now be root based on the txs removed
+		self.pool.update_roots();
+
 		removed_txs
 	}
 

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -16,7 +16,7 @@
 //! and its top-level members.
 
 use std::vec::Vec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::iter::Iterator;
 use std::fmt;
 
@@ -265,7 +265,7 @@ impl Pool {
 	pub fn remove_pool_transaction(
 		&mut self,
 		tx: &transaction::Transaction,
-		marked_txs: &HashMap<hash::Hash, ()>,
+		marked_txs: &HashSet<hash::Hash>,
 	) {
 
 		self.graph.remove_vertex(graph::transaction_identifier(tx));
@@ -273,7 +273,7 @@ impl Pool {
 		for input in tx.inputs.iter().map(|x| x.commitment()) {
 			match self.graph.remove_edge_by_commitment(&input) {
 				Some(x) => {
-					if !marked_txs.contains_key(&x.source_hash().unwrap()) {
+					if !marked_txs.contains(&x.source_hash().unwrap()) {
 						self.available_outputs.insert(
 							x.output_commitment(),
 							x.with_destination(None),
@@ -289,7 +289,7 @@ impl Pool {
 		for output in tx.outputs.iter().map(|x| x.commitment()) {
 			match self.graph.remove_edge_by_commitment(&output) {
 				Some(x) => {
-					if !marked_txs.contains_key(&x.destination_hash().unwrap()) {
+					if !marked_txs.contains(&x.destination_hash().unwrap()) {
 
 						self.consumed_blockchain_outputs.insert(
 							x.output_commitment(),

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -258,6 +258,10 @@ impl Pool {
 		}
 	}
 
+	pub fn update_roots(&mut self) {
+		self.graph.update_roots()
+	}
+
 	pub fn remove_pool_transaction(
 		&mut self,
 		tx: &transaction::Transaction,
@@ -298,10 +302,6 @@ impl Pool {
 				}
 			};
 		}
-
-		// now update the list of roots in the pool to reflect the current state
-		// a non-root vertex may become a root if an adjacent tx was removed
-		self.graph.update_roots()
 	}
 
 	/// Simplest possible implementation: just return the roots

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -206,6 +206,13 @@ impl Pool {
 			.map(|x| x.destination_hash().unwrap())
 	}
 
+	pub fn len_roots(&self) -> usize {
+		self.graph.len_roots()
+	}
+
+	pub fn len_vertices(&self) -> usize {
+		self.graph.len_vertices()
+	}
 
 	pub fn get_blockchain_spent(&self, c: &Commitment) -> Option<&graph::Edge> {
 		self.consumed_blockchain_outputs.get(c)

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -298,6 +298,10 @@ impl Pool {
 				}
 			};
 		}
+
+		// now update the list of roots in the pool to reflect the current state
+		// a non-root vertex may become a root if an adjacent tx was removed
+		self.graph.update_roots()
 	}
 
 	/// Simplest possible implementation: just return the roots


### PR DESCRIPTION
This fixes the issue I was seeing in #181 
We can now successfully spend a zero confirmation change output and it will get mined after a couple of blocks.
We currently only mine `roots` from the pool - this PR ensures `roots` is consistent after we call `reconcile_block`.

* introduced `update_roots` to ensure the pool is consistent after reconciliation
* remove duplicates before marking txs (leverage sets here)
* use HashSet instead of HashMap when marking txs

