### PR TITLE
update cuckoo miner tag

### DIFF
--- a/pow/Cargo.toml
+++ b/pow/Cargo.toml
@@ -18,7 +18,7 @@ grin_util = { path = "../util" }
 
 [dependencies.cuckoo_miner]
 git = "https://github.com/mimblewimble/cuckoo-miner"
-tag="barrier_test"
+tag="grin_integration_14"
 #path = "../../cuckoo-miner"
 #uncomment this feature to turn off plugin builds
 #features=["no-plugin-build"]


### PR DESCRIPTION
Update cuckoo miner tag, which should fix osx pthread barrier deadlock issue. Both issues below can be closed.

https://github.com/ignopeverell/grin/issues/143

https://github.com/mimblewimble/cuckoo-miner/issues/12

