### PR TITLE
wallet can now optionally spend zero-confirmation txs

### DIFF
--- a/pool/src/graph.rs
+++ b/pool/src/graph.rs
@@ -233,6 +233,20 @@ impl DirectedGraph {
 	pub fn get_roots(&self) -> Vec<core::hash::Hash> {
 		self.roots.iter().map(|x| x.transaction_hash).collect()
 	}
+
+	/// Get list of all vertices in this graph including the roots
+	pub fn get_vertices(&self) -> Vec<core::hash::Hash> {
+		let mut hashes = self.roots
+			.iter()
+			.map(|x| x.transaction_hash)
+			.collect::<Vec<_>>();
+		let non_root_hashes = self.vertices
+			.iter()
+			.map(|x| x.transaction_hash)
+			.collect::<Vec<_>>();
+		hashes.extend(&non_root_hashes);
+		return hashes
+	}
 }
 
 /// Using transaction merkle_inputs_outputs to calculate a deterministic hash;

--- a/pool/src/types.rs
+++ b/pool/src/types.rs
@@ -293,11 +293,17 @@ impl Pool {
 		}
 	}
 
-	/// Simplest possible implementation: just return the roots
+	/// Currently a single rule for miner preference -
+	/// return all txs if less than num_to_fetch txs in the entire pool
+	/// otherwise return num_to_fetch of just the roots
 	pub fn get_mineable_transactions(&self, num_to_fetch: u32) -> Vec<hash::Hash> {
-		let mut roots = self.graph.get_roots();
-		roots.truncate(num_to_fetch as usize);
-		roots
+		if self.graph.len_vertices() <= num_to_fetch as usize {
+			self.graph.get_vertices()
+		} else {
+			let mut roots = self.graph.get_roots();
+			roots.truncate(num_to_fetch as usize);
+			roots
+		}
 	}
 }
 

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -200,6 +200,12 @@ fn main() {
 			.arg(Arg::with_name("amount")
 				.help("Amount to send in the smallest denomination")
 				.index(1))
+			.arg(Arg::with_name("minimum_confirmations")
+				.help("Minimum number of confirmations required for an output to be spendable.")
+				.short("c")
+				.long("min_conf")
+				.default_value("1")
+				.takes_value(true))
 			.arg(Arg::with_name("dest")
 				.help("Send the transaction to the provided server")
 				.short("d")
@@ -212,7 +218,13 @@ fn main() {
 				transactions.")
 			.arg(Arg::with_name("amount")
 				.help("Amount to burn in the smallest denomination")
-				.index(1)))
+				.index(1))
+			.arg(Arg::with_name("minimum_confirmations")
+				.help("Minimum number of confirmations required for an output to be spendable.")
+				.short("c")
+				.long("min_conf")
+				.default_value("1")
+				.takes_value(true)))
 
 		.subcommand(SubCommand::with_name("info")
 			.about("basic wallet info (outputs)")))
@@ -380,11 +392,22 @@ fn wallet_command(wallet_args: &ArgMatches) {
 				.expect("Amount to send required")
 				.parse()
 				.expect("Could not parse amount as a whole number.");
+			let minimum_confirmations: u64 = send_args
+				.value_of("minimum_confirmations")
+				.unwrap_or("1")
+				.parse()
+				.expect("Could not parse minimum_confirmations as a whole number.");
 			let mut dest = "stdout";
 			if let Some(d) = send_args.value_of("dest") {
 				dest = d;
 			}
-			wallet::issue_send_tx(&wallet_config, &keychain, amount, dest.to_string()).unwrap();
+			wallet::issue_send_tx(
+				&wallet_config,
+				&keychain,
+				amount,
+				minimum_confirmations,
+				dest.to_string()
+			).unwrap();
 		}
 		("burn", Some(send_args)) => {
 			let amount = send_args
@@ -392,7 +415,17 @@ fn wallet_command(wallet_args: &ArgMatches) {
 				.expect("Amount to burn required")
 				.parse()
 				.expect("Could not parse amount as a whole number.");
-			wallet::issue_burn_tx(&wallet_config, &keychain, amount).unwrap();
+			let minimum_confirmations: u64 = send_args
+				.value_of("minimum_confirmations")
+				.unwrap_or("1")
+				.parse()
+				.expect("Could not parse minimum_confirmations as a whole number.");
+			wallet::issue_burn_tx(
+				&wallet_config,
+				&keychain,
+				amount,
+				minimum_confirmations,
+			).unwrap();
 		}
 		("info", Some(_)) => {
 			wallet::show_info(&wallet_config, &keychain);

--- a/wallet/src/receiver.rs
+++ b/wallet/src/receiver.rs
@@ -172,10 +172,11 @@ impl ApiEndpoint for WalletReceiver {
 }
 
 /// Build a coinbase output and the corresponding kernel
-fn receive_coinbase(config: &WalletConfig,
-                    keychain: &Keychain,
-                    block_fees: &BlockFees)
-                    -> Result<(Output, TxKernel, BlockFees), Error> {
+fn receive_coinbase(
+	config: &WalletConfig,
+	keychain: &Keychain,
+	block_fees: &BlockFees
+) -> Result<(Output, TxKernel, BlockFees), Error> {
 	let root_key_id = keychain.root_key_id();
 
 	// operate within a lock on wallet data
@@ -205,7 +206,7 @@ fn receive_coinbase(config: &WalletConfig,
 			status: OutputStatus::Unconfirmed,
 			height: 0,
 			lock_height: 0,
-			zero_ok: false,
+			is_coinbase: true,
 		});
 
 		debug!(
@@ -280,7 +281,7 @@ fn receive_transaction(
 			status: OutputStatus::Unconfirmed,
 			height: 0,
 			lock_height: 0,
-			zero_ok: false,
+			is_coinbase: false,
 		});
 		debug!(
 			LOGGER,

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -191,10 +191,8 @@ impl OutputData {
 		} else if self.lock_height > current_height {
 			return false;
 		} else if self.status == OutputStatus::Unspent && self.height + minimum_confirmations <= current_height {
-			println!("************** eligible to spend - {:?}, {}, {}, {}", self.status, self.height, current_height, minimum_confirmations);
 			return true;
 		} else if self.status == OutputStatus::Unconfirmed && minimum_confirmations == 0 {
-			println!("********** zero conf eligible to spend");
 			return true;
 		} else {
 			return false;

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -132,7 +132,6 @@ impl Default for WalletConfig {
 pub enum OutputStatus {
 	Unconfirmed,
 	Unspent,
-	Immature,
 	Locked,
 	Spent,
 }
@@ -142,7 +141,6 @@ impl fmt::Display for OutputStatus {
 		match *self {
 			OutputStatus::Unconfirmed => write!(f, "Unconfirmed"),
 			OutputStatus::Unspent => write!(f, "Unspent"),
-			OutputStatus::Immature => write!(f, "Immature"),
 			OutputStatus::Locked => write!(f, "Locked"),
 			OutputStatus::Spent => write!(f, "Spent"),
 		}
@@ -168,14 +166,39 @@ pub struct OutputData {
 	pub height: u64,
 	/// Height we are locked until
 	pub lock_height: u64,
-	/// Can we spend with zero confirmations? (Did it originate from us, change output etc.)
-	pub zero_ok: bool,
+	/// Is this a coinbase output? Is it subject to coinbase locktime?
+	pub is_coinbase: bool,
 }
 
 impl OutputData {
 	/// Lock a given output to avoid conflicting use
 	fn lock(&mut self) {
 		self.status = OutputStatus::Locked;
+	}
+
+	pub fn eligible_to_spend(
+		&self,
+		current_height: u64,
+		minimum_confirmations: u64
+	) -> bool {
+		if [
+			OutputStatus::Spent,
+			OutputStatus::Locked,
+		].contains(&self.status) {
+			return false;
+		} else if self.status == OutputStatus::Unconfirmed && self.is_coinbase {
+			return false;
+		} else if self.lock_height > current_height {
+			return false;
+		} else if self.status == OutputStatus::Unspent && self.height + minimum_confirmations <= current_height {
+			println!("************** eligible to spend - {:?}, {}, {}, {}", self.status, self.height, current_height, minimum_confirmations);
+			return true;
+		} else if self.status == OutputStatus::Unconfirmed && minimum_confirmations == 0 {
+			println!("********** zero conf eligible to spend");
+			return true;
+		} else {
+			return false;
+		}
 	}
 }
 
@@ -313,27 +336,22 @@ impl WalletData {
 		self.outputs.get(&key_id.to_hex())
 	}
 
-	/// Select a subset of unspent outputs to spend in a transaction
-	/// transferring the provided amount.
-	pub fn select(&self, root_key_id: keychain::Identifier, amount: u64) -> (Vec<OutputData>, i64) {
-		let mut to_spend = vec![];
-		let mut input_total = 0;
+	/// Select spendable coins from the wallet
+	pub fn select(
+		&self,
+		root_key_id: keychain::Identifier,
+		current_height: u64,
+		minimum_confirmations: u64,
+	) -> Vec<OutputData> {
 
-		for out in self.outputs.values() {
-			if out.root_key_id == root_key_id
-				&& (out.status == OutputStatus::Unspent)
-					// the following will let us spend zero confirmation change outputs
-					// || (out.status == OutputStatus::Unconfirmed && out.zero_ok))
-			{
-				to_spend.push(out.clone());
-				input_total += out.value;
-				if input_total >= amount {
-					break;
-				}
-			}
-		}
-		// TODO - clean up our handling of i64 vs u64 so we are consistent
-		(to_spend, (input_total as i64) - (amount as i64))
+		self.outputs
+			.values()
+			.filter(|out| {
+				out.root_key_id == root_key_id
+					&& out.eligible_to_spend(current_height, minimum_confirmations)
+			})
+			.map(|out| out.clone())
+			.collect()
 	}
 
 	/// Next child index when we want to create a new output.


### PR DESCRIPTION
This indirectly relies on #182 being merged first (so the tx pool behaves as expected).

Cleanup wallet coin selection logic - 
* wallet can now optionally spend zero-confirmation txs
  * send & burn both support `minimum_confirmations` argument
* cleanup wallet output data statuses
* cleanup wallet coin selection logic

Add single rule to `get_mineable_transactions` -
* if total pool size is smaller than # txs we can mine then mine them all
* otherwise, just mine the root txs in the pool

This allows to to test out chaining zero confirmation txs in the pool and mining them in a single block.


```
wallet send --help

USAGE:
    grin wallet send [OPTIONS] [amount]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -d, --dest <dest>
            Send the transaction to the provided server

    -c, --min_conf <minimum_confirmations>
            Minimum number of confirmations required for an output to be spendable.
            [default: 1]
```
