### PR TITLE
Bind to services to all interfaces rather than loopback

### DIFF
--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -603,7 +603,6 @@ impl Miner {
 				"{}/v1/receive/coinbase",
 				self.config.wallet_receiver_url.as_str()
 			);
-			trace!(LOGGER, "Coinbase receiver URL: {}", url);
 			let request = WalletReceiveRequest::Coinbase(block_fees.clone());
 			let res: CbData = api::client::post(url.as_str(), &request).expect(
 				format!(

--- a/grin/src/miner.rs
+++ b/grin/src/miner.rs
@@ -603,6 +603,7 @@ impl Miner {
 				"{}/v1/receive/coinbase",
 				self.config.wallet_receiver_url.as_str()
 			);
+			trace!(LOGGER, "Coinbase receiver URL: {}", url);
 			let request = WalletReceiveRequest::Coinbase(block_fees.clone());
 			let res: CbData = api::client::post(url.as_str(), &request).expect(
 				format!(

--- a/grin/src/types.rs
+++ b/grin/src/types.rs
@@ -108,7 +108,7 @@ impl Default for ServerConfig {
 	fn default() -> ServerConfig {
 		ServerConfig {
 			db_root: ".grin".to_string(),
-			api_http_addr: "127.0.0.1:13415".to_string(),
+			api_http_addr: "0.0.0.0:13415".to_string(),
 			capabilities: p2p::FULL_NODE,
 			seeding_type: Seeding::None,
 			seeds: None,

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -73,7 +73,7 @@ pub struct P2PConfig {
 /// Default address for peer-to-peer connections.
 impl Default for P2PConfig {
 	fn default() -> P2PConfig {
-		let ipaddr = "127.0.0.1".parse().unwrap();
+		let ipaddr = "0.0.0.0".parse().unwrap();
 		P2PConfig {
 			host: ipaddr,
 			port: 13414,

--- a/src/bin/grin.rs
+++ b/src/bin/grin.rs
@@ -283,7 +283,7 @@ fn server_command(server_args: &ArgMatches, global_config: GlobalConfig) {
 	}
 
 	if let Some(api_port) = server_args.value_of("api_port") {
-		let default_ip = "127.0.0.1";
+		let default_ip = "0.0.0.0";
 		server_config.api_http_addr = format!("{}:{}", default_ip, api_port);
 	}
 
@@ -345,7 +345,7 @@ fn wallet_command(wallet_args: &ArgMatches) {
 
 	let mut wallet_config = WalletConfig::default();
 	if let Some(port) = wallet_args.value_of("port") {
-		let default_ip = "127.0.0.1";
+		let default_ip = "0.0.0.0";
 		wallet_config.api_http_addr = format!("{}:{}", default_ip, port);
 	}
 

--- a/wallet/src/types.rs
+++ b/wallet/src/types.rs
@@ -117,7 +117,7 @@ impl Default for WalletConfig {
 	fn default() -> WalletConfig {
 		WalletConfig {
 			enable_wallet: false,
-			api_http_addr: "127.0.0.1:13416".to_string(),
+			api_http_addr: "0.0.0.0:13416".to_string(),
 			check_node_api_http_addr: "http://127.0.0.1:13413".to_string(),
 			data_file_dir: ".".to_string(),
 		}


### PR DESCRIPTION
The p2p and endpoints were binding to 127.0.0.1, i.e. the loopback adapter, and not accessible from outside machines. I think we're going to need a way to explicitly specify the adapter to bind to, but this just solves the issue for now to allow to test multi-machine setups via docker.